### PR TITLE
Make logs at debug level visible in phone console

### DIFF
--- a/Source/ZMSAppleSystemLoggerWrapper.m
+++ b/Source/ZMSAppleSystemLoggerWrapper.m
@@ -70,7 +70,8 @@
 - (void)sendMessage:(ZMSASLMessage *)message;
 {
     asl_object_t msg = NULL;
-    asl_log(_backingClient, msg, (int) message.level, "%s", message.messageText.UTF8String);
+    int level = MAX(ASL_LEVEL_NOTICE, (int) message.level); // if it's not at least ASL_LEVEL_NOTICE it won't show up in console
+    asl_log(_backingClient, msg, level, "%s", message.messageText.UTF8String);
 }
 
 - (void)dealloc


### PR DESCRIPTION
# Reason for this pull request
Logs at `debug` level generated from Swift code were not visible in iPhone console

# Changes
Make sure logs are forced to at least `ASL_LEVEL_NOTICE`, which is the minimum for it to be displayed in phone console

# Testing
Can't easily test this unfortunately