### PR TITLE
ZIOS-9956: Avoid non-AVS logs inside the calling logs for public builds

### DIFF
--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -23,10 +23,11 @@ private var recordingToken : ZMSLog.LogHookToken? = nil
 extension ZMSLog {
     
     /// Start recording
-    public static func startRecording(size: Int = 10000) {
+    public static func startRecording(isInternal: Bool = true) {
         logQueue.sync {
             if recordingToken == nil {
                 recordingToken = self.nonLockingAddHook(logHook: { (level, tag, message) -> (Void) in
+                    guard isInternal || (!isInternal && level != .error) else { return }
                     let tagString = tag.flatMap { "[\($0)] "} ?? ""
                     ZMSLog.appendToCurrentLog("\(Date()): [\(level.rawValue)] \(tagString)\(message)\n")
                 })

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -416,16 +416,7 @@ extension ZMLogTests {
         Thread.sleep(forTimeInterval: 0.2)
         
         // THEN
-        guard let currentLog = ZMSLog.currentLog,
-            let logContent = String(data: currentLog, encoding: .utf8) else {
-            XCTFail()
-            return
-        }
-        
-        var lines: [String] = []
-        logContent.enumerateLines { (str, _) in
-            lines.append(str)
-        }
+        let lines = getLinesFromCurrentLog()
 
         XCTAssertEqual(lines.count, 2)
         XCTAssertTrue(lines.first!.hasSuffix("[0] [foo] PANIC"))
@@ -491,4 +482,86 @@ extension ZMLogTests {
         
     }
     
+}
+
+extension ZMLogTests {
+    
+    func testThatItSavesDebugTagsInProduction() {
+        
+        //given
+        let tag = "tag"
+        let sut = ZMSLog(tag: tag)
+        
+        ZMSLog.startRecording(isInternal: false)
+        
+        ZMSLog.set(level: .error, tag: tag)
+        sut.error("ERROR")
+        
+        ZMSLog.set(level: .warn, tag: tag)
+        sut.warn("WARN")
+        
+        ZMSLog.set(level: .info, tag: tag)
+        sut.info("INFO")
+        
+        ZMSLog.set(level: .debug, tag: tag)
+        sut.debug("DEBUG")
+        
+        Thread.sleep(forTimeInterval: 0.5)
+        
+        let lines = getLinesFromCurrentLog()
+        
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertFalse(lines.first!.hasSuffix("[0] [tag] ERROR"))
+        XCTAssertTrue(lines[0].hasSuffix("[1] [tag] WARN"))
+        XCTAssertTrue(lines[1].hasSuffix("[2] [tag] INFO"))
+        XCTAssertTrue(lines[2].hasSuffix("[3] [tag] DEBUG"))
+    }
+    
+    func testThatItSavesAllLevelsOnInternals() {
+        
+        //given
+        let tag = "tag"
+        let sut = ZMSLog(tag: tag)
+        
+        ZMSLog.startRecording(isInternal: true)
+        
+        ZMSLog.set(level: .error, tag: tag)
+        sut.error("ERROR")
+        
+        ZMSLog.set(level: .warn, tag: tag)
+        sut.warn("WARN")
+        
+        ZMSLog.set(level: .info, tag: tag)
+        sut.info("INFO")
+        
+        ZMSLog.set(level: .debug, tag: tag)
+        sut.debug("DEBUG")
+        
+        Thread.sleep(forTimeInterval: 0.5)
+        
+        let lines = getLinesFromCurrentLog()
+        
+        XCTAssertEqual(lines.count, 4)
+        XCTAssertTrue(lines[0].hasSuffix("[0] [tag] ERROR"))
+        XCTAssertTrue(lines[1].hasSuffix("[1] [tag] WARN"))
+        XCTAssertTrue(lines[2].hasSuffix("[2] [tag] INFO"))
+        XCTAssertTrue(lines[3].hasSuffix("[3] [tag] DEBUG"))
+    }
+    
+    
+    func getLinesFromCurrentLog() -> [String] {
+        
+        guard let currentLog = ZMSLog.currentLog,
+            let logContent = String(data: currentLog, encoding: .utf8) else {
+                XCTFail()
+                return []
+        }
+        
+        var lines: [String] = []
+        logContent.enumerateLines { (str, _) in
+            lines.append(str)
+        }
+        
+        return lines
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Logs at level 0 (errors) were logged on both production and internal builds.

### Solutions

I'm excluding errors to be logged on production builds (with developer menu disabled). I've also added tests and removed the size of the log, since we don't have the circular array in memory anymore.