### PR TITLE
ZIOS-9925: Add milliseconds to the log entries

### DIFF
--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -28,7 +28,7 @@ extension ZMSLog {
             if recordingToken == nil {
                 recordingToken = self.nonLockingAddHook(logHook: { (level, tag, message) -> (Void) in
                     let tagString = tag.flatMap { "[\($0)] "} ?? ""
-                    ZMSLog.appendToCurrentLog("\(Date()): [\(level.rawValue)] \(tagString)\(message)\n")
+                    ZMSLog.appendToCurrentLog("\(currentDate): [\(level.rawValue)] \(tagString)\(message)\n")
                 })
             }
         }
@@ -46,6 +46,16 @@ extension ZMSLog {
         if let token = tokenToRemove {
             self.removeLogHook(token: token)
         }
+    }
+    
+    private static var currentDate: String {
+        return dateFormatter.string(from: Date())
+    }
+    
+    private static var dateFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS Z"
+        return df
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

It is necessary for AVS debugging to see the more detailed timing of the log entries.

### Solutions

I've added the milliseconds to the logs by using a static `DateFormatter` object instead of istantiating the `Date` object directly. The new date format is `yyyy-MM-dd HH:mm:ss.SSSS Z`.