### PR TITLE
Added post test step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   environment:
-    - DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/feature/fastlane"
+    - DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/fix/add-post-test"
   macos:
     xcode: "9.3.0"
   shell: /bin/bash --login -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   environment:
-    - DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/fix/add-post-test"
+    - DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master"
   macos:
     xcode: "9.3.0"
   shell: /bin/bash --login -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,9 @@ jobs:
     - run: 
         name: "Test"
         command: bundle exec fastlane test
+    - run: 
+        name: "Post test"
+        command: bundle exec fastlane post_test
     - store_artifacts:
         path: SnapshotResults
     - store_test_results:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,1 +1,1 @@
-import_from_git(url: 'https://github.com/wireapp/wire-ios-shared-resources.git', branch: "fix/add-post-test", path: "Fastlane/Frameworks")
+import_from_git(url: 'https://github.com/wireapp/wire-ios-shared-resources.git', branch: "master", path: "Fastlane/Frameworks")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,1 +1,1 @@
-import_from_git(url: 'https://github.com/wireapp/wire-ios-shared-resources.git', branch: "feature/fastlane", path: "Fastlane/Frameworks")
+import_from_git(url: 'https://github.com/wireapp/wire-ios-shared-resources.git', branch: "fix/add-post-test", path: "Fastlane/Frameworks")


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some functionality was still missing after migrating to Fastlane scripts - uploading test coverage info and running Danger.

### Solutions

After tests running `fastlane post_test` step.

## Dependencies

Needs to be updated when this is merged:

- [x] https://github.com/wireapp/wire-ios-shared-resources/pull/20