### PR TITLE
Cache implementation based on CircularArray

### DIFF
--- a/Source/Cache.swift
+++ b/Source/Cache.swift
@@ -58,6 +58,7 @@ public class Cache<Key: Hashable, Value> {
     public func purge() {
         cache.removeAll()
         cacheBuffer.clear()
+        currentCost = 0
     }
 
     private func purgeBasedOnElementsCount(adding key: Key) {

--- a/Source/Cache.swift
+++ b/Source/Cache.swift
@@ -1,0 +1,105 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public class Cache<Key: Hashable, Value> {
+    private var cache: [Key: EntryMetadata<Value>] = [:]
+    private var cacheBuffer: CircularArray<Key>
+    private let maxCost: Int
+    private let maxElementsCount: Int
+    private var currentCost: Int = 0
+    
+    private struct EntryMetadata<Value> {
+        let value: Value
+        let cost: Int
+        
+        init(value: Value, cost: Int) {
+            self.value = value
+            self.cost = cost
+        }
+    }
+    
+    public init(maxCost: Int, maxElementsCount: Int) {
+        assert(maxCost > 0, "maxCost must be greather than 0")
+        assert(maxElementsCount > 0, "maxElementsCount must be greather than 0")
+        self.maxCost = maxCost
+        self.maxElementsCount = maxElementsCount
+        cacheBuffer = CircularArray<Key>(size: maxElementsCount)
+    }
+    
+    public func set(value: Value, for key: Key, cost: Int) {
+        assert(cost > 0, "Cost must be greather than 0")
+        cache[key] = EntryMetadata(value: value, cost: cost)
+        currentCost = currentCost + cost
+        purgeBasedOnElementsCount(adding: key)
+        purgeBasedOnCost()
+    }
+    
+    public func value(for key: Key) -> Value? {
+        return cache[key]?.value
+    }
+    
+    public func purge() {
+        cache.removeAll()
+        cacheBuffer.clear()
+    }
+
+    private func purgeBasedOnElementsCount(adding key: Key) {
+        guard let discardedElement = cacheBuffer.add(key) else {
+            return
+        }
+        let metadata = cache[discardedElement]!
+        currentCost = currentCost - metadata.cost
+
+        cache[discardedElement] = nil
+    }
+    
+    private func purgeBasedOnCost() {
+        guard currentCost > maxCost else {
+            return
+        }
+        
+        var elementsToDiscard: Int = 0
+
+        // Get the objects from the current cache buffer
+        let currentCacheBuffer = cacheBuffer.content
+        
+        for key in currentCacheBuffer {
+            // Find the corresponding element's metadata
+            let metadata = cache[key]!
+            
+            // Advance one index forward
+            elementsToDiscard = elementsToDiscard + 1
+
+            // Erase cached object from the cache
+            cache[key] = nil
+            currentCost = currentCost - metadata.cost
+            
+            // check if the cost is back to normal
+            if currentCost <= maxCost {
+                break
+            }
+        }
+
+        // rebuild cacheBuffer, since as many as `elementsToDiscard` number of elements must be discarded
+        cacheBuffer = CircularArray(size: maxElementsCount,
+                                    initialValue: Array(currentCacheBuffer.prefix(upTo: currentCacheBuffer.count - elementsToDiscard)))
+    }
+    
+}

--- a/Source/CircularArray.swift
+++ b/Source/CircularArray.swift
@@ -21,7 +21,7 @@ import Foundation
 /// A circular array behaves like an array, but once it reaches a maximum size
 /// new elements that are inserted will overwrite the oldest elements, allowing
 /// for inserting an infinite amount of elements (at the cost of discarding the old ones)
-public struct CircularArray<T> {
+public struct CircularArray<Element> {
     
     /// Max size
     private let size : Int
@@ -30,7 +30,7 @@ public struct CircularArray<T> {
     /// Once it reaches the end (full), it starts to overwrite from the beginning
     /// The same operation could be achieved by appending to the end and removing from
     /// the front, but this would cause reallocating the array
-    private var circularArray : [T]
+    private var circularArray : [Element]
     
     /// Where to insert the next element
     private var listEnd = 0
@@ -40,18 +40,25 @@ public struct CircularArray<T> {
     }
     
     /// Insert an element in the array
-    public mutating func add(_ element: T) {
+    /// - Returns: old element that is going to be replaced with @c element
+    @discardableResult public mutating func add(_ element: Element) -> Element? {
+        let discardedElement: Element?
+        
         if !self.isFull {
             circularArray.append(element)
+            discardedElement = nil
         } else {
+            discardedElement = circularArray[listEnd]
             circularArray[listEnd] = element
         }
 
         listEnd = (listEnd + 1) % size
+        
+        return discardedElement
     }
     
     /// Returns the cache content
-    public var content : [T] {
+    public var content : [Element] {
         if self.isFull {
             return Array(circularArray[listEnd..<size]) + Array(circularArray[0..<listEnd])
         }
@@ -65,9 +72,9 @@ public struct CircularArray<T> {
         self.circularArray.reserveCapacity(size)
     }
     
-    public init(size: Int) {
+    public init(size: Int, initialValue: [Element] = []) {
         self.size = size
-        self.circularArray = []
+        self.circularArray = initialValue
         self.circularArray.reserveCapacity(size)
     }
 }

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -1,0 +1,80 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import XCTest
+@testable import WireSystem
+
+class CacheTests: XCTestCase {
+    func testThatItStoresAndReadsValue() {
+        // GIVEN
+        let cache = Cache<String, String>(maxCost: 1000, maxElementsCount: 10)
+        // WHEN
+        cache.set(value: "Hello", for: "word", cost: 1)
+        // THEN
+        XCTAssertEqual(cache.value(for: "word"), "Hello")
+    }
+    
+    func testThatItPurgesWhenTooManyElements() {
+        // GIVEN
+        let cache = Cache<String, String>(maxCost: 1000, maxElementsCount: 10)
+        // WHEN
+        (0..<11).forEach {
+            cache.set(value: "Hello \($0)", for: "word \($0)", cost: 1)
+        }
+        
+        // THEN
+        XCTAssertEqual(cache.value(for: "word 10"), "Hello 10")
+        XCTAssertEqual(cache.value(for: "word 1"), "Hello 1")
+        XCTAssertEqual(cache.value(for: "word 0"), nil)
+    }
+    
+    func testThatItPurgesWhenCostIsTooHigh() {
+        // GIVEN
+        let cache = Cache<String, String>(maxCost: 10, maxElementsCount: 10)
+        // WHEN
+        cache.set(value: "Hello 0", for: "word 0", cost: 2)
+        cache.set(value: "Hello 1", for: "word 1", cost: 2)
+        cache.set(value: "Hello 2", for: "word 2", cost: 2)
+        cache.set(value: "Hello 3", for: "word 3", cost: 5)
+        
+        // THEN
+        XCTAssertEqual(cache.value(for: "word 3"), "Hello 3")
+        XCTAssertEqual(cache.value(for: "word 2"), "Hello 2")
+        XCTAssertEqual(cache.value(for: "word 1"), "Hello 1")
+        XCTAssertEqual(cache.value(for: "word 0"), nil)
+    }
+    
+    func testThatItPurgesWhenCostIsTooHigh_MultipleDeletes() {
+        // GIVEN
+        let cache = Cache<String, String>(maxCost: 10, maxElementsCount: 10)
+        // WHEN
+        cache.set(value: "Hello 0", for: "word 0", cost: 1)
+        cache.set(value: "Hello 1", for: "word 1", cost: 1)
+        cache.set(value: "Hello 2", for: "word 2", cost: 3)
+        cache.set(value: "Hello 3", for: "word 3", cost: 5)
+        cache.set(value: "Hello 4", for: "word 4", cost: 5)
+        
+        // THEN
+        XCTAssertEqual(cache.value(for: "word 4"), "Hello 4")
+        XCTAssertEqual(cache.value(for: "word 3"), "Hello 3")
+        XCTAssertEqual(cache.value(for: "word 2"), nil)
+        XCTAssertEqual(cache.value(for: "word 1"), nil)
+        XCTAssertEqual(cache.value(for: "word 0"), nil)
+    }
+}

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -77,4 +77,23 @@ class CacheTests: XCTestCase {
         XCTAssertEqual(cache.value(for: "word 1"), nil)
         XCTAssertEqual(cache.value(for: "word 0"), nil)
     }
+
+    func testThatPurgeResetsContent() {
+        // GIVEN
+        let cache = Cache<String, String>(maxCost: 5, maxElementsCount: 5)
+        // WHEN
+        cache.set(value: "Hello 0", for: "word 0", cost: 5)
+        
+        // AND WHEN
+        cache.purge()
+        
+        // THEN
+        XCTAssertEqual(cache.value(for: "word 0"), nil)
+        
+        // AND WHEN
+        cache.set(value: "Goodbye 0", for: "word 0", cost: 5)
+        
+        // THEN
+        XCTAssertEqual(cache.value(for: "word 0"), "Goodbye 0")
+    }
 }

--- a/WireSystem.xcodeproj/project.pbxproj
+++ b/WireSystem.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		54FF9F121C48F67300B29ACE /* ZMSTimePoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FF9F101C48F67300B29ACE /* ZMSTimePoint.m */; };
 		54FF9F141C4906C700B29ACE /* ZMTimePointTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FF9F131C4906C700B29ACE /* ZMTimePointTests.m */; };
 		54FF9F161C4914D100B29ACE /* ZMSTestDetectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FF9F151C4914D100B29ACE /* ZMSTestDetectionTests.m */; };
+		8701221620F64171001E6342 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8701221520F64171001E6342 /* Cache.swift */; };
+		8701221920F641BE001E6342 /* CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8701221720F641A4001E6342 /* CacheTests.swift */; };
 		D59F3A1B206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59F3A1A206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift */; };
 		D59F3A1D206A47E80023474F /* DispatchQueueHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */; };
 /* End PBXBuildFile section */
@@ -106,6 +108,8 @@
 		54FF9F101C48F67300B29ACE /* ZMSTimePoint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMSTimePoint.m; sourceTree = "<group>"; };
 		54FF9F131C4906C700B29ACE /* ZMTimePointTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMTimePointTests.m; sourceTree = "<group>"; };
 		54FF9F151C4914D100B29ACE /* ZMSTestDetectionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMSTestDetectionTests.m; sourceTree = "<group>"; };
+		8701221520F64171001E6342 /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
+		8701221720F641A4001E6342 /* CacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheTests.swift; sourceTree = "<group>"; };
 		D59F3A1A206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+ZMSDispatchGroup.swift"; sourceTree = "<group>"; };
 		D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueHelperTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -167,6 +171,7 @@
 		5473E7C61B31A95A00C6A937 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				8701221520F64171001E6342 /* Cache.swift */,
 				54180BD61F459DCF0020D2BD /* MemoryReferenceDebugger.h */,
 				54180BD71F459DCF0020D2BD /* MemoryReferenceDebugger.swift */,
 				54F5148B1B7377CA00FACDAA /* ZMSGroupQueue.h */,
@@ -218,6 +223,7 @@
 		54A327381B99A3650004EB95 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				8701221720F641A4001E6342 /* CacheTests.swift */,
 				54180BDA1F459DFB0020D2BD /* MemoryReferenceDebuggerTests.m */,
 				54180BDB1F459DFB0020D2BD /* MemoryReferenceDebuggerTests.swift */,
 				54A327391B99A3840004EB95 /* ZMLoggingTests.m */,
@@ -372,6 +378,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				544CFC511B70B933007AA694 /* ZMSLog.swift in Sources */,
+				8701221620F64171001E6342 /* Cache.swift in Sources */,
 				54180BD91F459DCF0020D2BD /* MemoryReferenceDebugger.swift in Sources */,
 				54F249C91BB9242900040600 /* ZMSDispatchGroup.m in Sources */,
 				54C0CC411C9C7635000A9286 /* ZMSAsserts.m in Sources */,
@@ -394,6 +401,7 @@
 			files = (
 				54C5DF8A1BBADA3D00DCFC95 /* ZMSDispatchGroupTests.m in Sources */,
 				54180BDE1F459DFF0020D2BD /* MemoryReferenceDebuggerTests.m in Sources */,
+				8701221920F641BE001E6342 /* CacheTests.swift in Sources */,
 				54A3273C1B99C04F0004EB95 /* ZMLogTests.swift in Sources */,
 				54FF9F161C4914D100B29ACE /* ZMSTestDetectionTests.m in Sources */,
 				D59F3A1D206A47E80023474F /* DispatchQueueHelperTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

This adds NSCache-like generic cache implementation. Known limitations: no way to discard the single element from cache.

Supports the cost and element count constraints.