### PR TITLE
Add requireInternalFailure function not needing a condition

### DIFF
--- a/Source/ZMSAsserts.swift
+++ b/Source/ZMSAsserts.swift
@@ -63,3 +63,9 @@ public func requireInternal(_ condition: Bool, _ message: @autoclosure () -> Str
     guard !Environment.current.isAppStore, !condition else { return }
     fatal(message(), file: file, line: line)
 }
+
+/// Termiantes the application if the current build is not an AppsStore build
+public func requireInternalFailure(_ message: @autoclosure () -> String, file: String = #file, line: Int = #line) {
+    guard !Environment.current.isAppStore else { return }
+    fatal(message(), file: file, line: line)
+}


### PR DESCRIPTION
## What's new in this PR?

* Similar to `preconditionFailure` this `requireInternalFailure` does not need a condition and will always terminate (useful in guards where the condition was already checked beforehand or example).