### PR TITLE
Adapt current logging system to use os.log

### DIFF
--- a/Source/ZMSLog+Levels.swift
+++ b/Source/ZMSLog+Levels.swift
@@ -60,14 +60,14 @@ private var logTagToLogger : [String : OSLog] = [:]
     }
 
     @available(iOS 10, *)
-    static func logger(tag: String?) -> OSLog? {
+    static func logger(tag: String?) -> OSLog {
         guard let tag = tag else { return OSLog.default }
         if logTagToLogger[tag] == nil {
             let bundleID = Bundle.main.bundleIdentifier ?? "com.wire.zmessaging.test"
             let logger = OSLog(subsystem: bundleID, category: tag)
             logTagToLogger[tag] = logger
         }
-        return logTagToLogger[tag]
+        return logTagToLogger[tag]!
     }
     
     /// Get all tags

--- a/Source/ZMSLog+Levels.swift
+++ b/Source/ZMSLog+Levels.swift
@@ -17,11 +17,13 @@
 //
 
 import Foundation
+import os.log
 
 // MARK: - Log level management
 
 /// Map of the level set for each log tag
 private var logTagToLevel : [String : ZMLogLevel_t] = [:]
+private var logTagToLogger : [String : OSLog] = [:]
 
 @objc extension ZMSLog {
     
@@ -55,6 +57,17 @@ private var logTagToLevel : [String : ZMLogLevel_t] = [:]
         if logTagToLevel[tag] == nil {
             logTagToLevel[tag] = ZMLogLevel_t.warn
         }
+    }
+
+    @available(iOS 10, *)
+    static func logger(tag: String?) -> OSLog? {
+        guard let tag = tag else { return OSLog.default }
+        if logTagToLogger[tag] == nil {
+            let bundleID = Bundle.main.bundleIdentifier ?? "com.wire.zmessaging.test"
+            let logger = OSLog(subsystem: bundleID, category: tag)
+            logTagToLogger[tag] = logger
+        }
+        return logTagToLogger[tag]
     }
     
     /// Get all tags

--- a/Source/ZMSLog.swift
+++ b/Source/ZMSLog.swift
@@ -18,6 +18,7 @@
 
 
 import Foundation
+import os.log
 
 /// A logging facility based on tags to switch on and off certain logs
 ///
@@ -167,6 +168,22 @@ extension ZMSLog {
     }
 }
 
+extension ZMLogLevel_t {
+    @available(iOS 10.0, *)
+    var logLevel: OSLogType {
+        switch self {
+        case .error:
+            return .error
+        case .warn:
+            return .error
+        case .info:
+            return .info
+        case .debug:
+            return .debug
+        }
+    }
+}
+
 // MARK: - Internal stuff
 extension ZMSLog {
     
@@ -179,7 +196,11 @@ extension ZMSLog {
             }
         
             if tag == nil || level.rawValue <= ZMSLog.getLevelNoLock(tag: tag!).rawValue {
-                sharedASLClient.sendMessage("\(file):\(line) \(tag ?? "") \(concreteMessage)", level: level)
+                if #available(iOS 10, *) {
+                    os_log("%{public}@", log: self.logger(tag: tag), type: level.logLevel, concreteMessage)
+                } else {
+                    sharedASLClient.sendMessage("\(file):\(line) \(tag ?? "") \(concreteMessage)", level: level)
+                }
                 self.notifyHooks(level: level, tag: tag, message: concreteMessage)
             }
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

New logging system introduced with iOS 10 supports some more features and formatting of logs in console.

### Solutions

The old logs still go through the new subsystem so we use it only on iOS9.
