### PR TITLE
Fix erratic log message timestamp

### DIFF
--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -26,11 +26,11 @@ extension ZMSLog {
     @objc public static func startRecording(isInternal: Bool = true) {
         logQueue.sync {
             if recordingToken == nil {
-                recordingToken = self.nonLockingAddMessageHook(logHook: { (level, tag, message) -> (Void) in
+                recordingToken = self.nonLockingAddEntryHook(logHook: { (level, tag, entry) -> (Void) in
                     guard isInternal || level != .error else { return }
                     let tagString = tag.flatMap { "[\($0)] "} ?? ""
-                    let date = dateFormatter.string(from: message.timestamp)
-                    ZMSLog.appendToCurrentLog("\(date): [\(level.rawValue)] \(tagString)\(message.text)\n")
+                    let date = dateFormatter.string(from: entry.timestamp)
+                    ZMSLog.appendToCurrentLog("\(date): [\(level.rawValue)] \(tagString)\(entry.text)\n")
                 })
             }
         }

--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -29,7 +29,8 @@ extension ZMSLog {
                 recordingToken = self.nonLockingAddHook(logHook: { (level, tag, message) -> (Void) in
                     guard isInternal || level != .error else { return }
                     let tagString = tag.flatMap { "[\($0)] "} ?? ""
-                    ZMSLog.appendToCurrentLog("\(currentDate): [\(level.rawValue)] \(tagString)\(message)\n")
+                    let date = dateFormatter.string(from: message.timestamp)
+                    ZMSLog.appendToCurrentLog("\(date): [\(level.rawValue)] \(tagString)\(message.text)\n")
                 })
             }
         }
@@ -48,11 +49,7 @@ extension ZMSLog {
             self.removeLogHook(token: token)
         }
     }
-    
-    private static var currentDate: String {
-        return dateFormatter.string(from: Date())
-    }
-    
+        
     private static var dateFormatter: DateFormatter {
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS Z"

--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -26,7 +26,7 @@ extension ZMSLog {
     @objc public static func startRecording(isInternal: Bool = true) {
         logQueue.sync {
             if recordingToken == nil {
-                recordingToken = self.nonLockingAddHook(logHook: { (level, tag, message) -> (Void) in
+                recordingToken = self.nonLockingAddMessageHook(logHook: { (level, tag, message) -> (Void) in
                     guard isInternal || level != .error else { return }
                     let tagString = tag.flatMap { "[\($0)] "} ?? ""
                     let date = dateFormatter.string(from: message.timestamp)
@@ -49,7 +49,7 @@ extension ZMSLog {
             self.removeLogHook(token: token)
         }
     }
-        
+
     private static var dateFormatter: DateFormatter {
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS Z"

--- a/Source/ZMSLog.swift
+++ b/Source/ZMSLog.swift
@@ -142,9 +142,9 @@ extension ZMSLog {
     }
     
     /// Notify all hooks of a new log
-    fileprivate static func notifyHooks(level: ZMLogLevel_t, tag: String?, message: ZMSLogEntry) {
+    fileprivate static func notifyHooks(level: ZMLogLevel_t, tag: String?, entry: ZMSLogEntry) {
         self.logHooks.forEach { (_, hook) in
-            hook(level, tag, message)
+            hook(level, tag, entry)
         }
     }
 
@@ -224,8 +224,8 @@ extension ZMSLog {
             }
         
             if tag == nil || level.rawValue <= ZMSLog.getLevelNoLock(tag: tag!).rawValue {
-                os_log("%{public}@", log: self.logger(tag: tag), type: level.logLevel, logEntry)
-                self.notifyHooks(level: level, tag: tag, message: logEntry)
+                os_log("%{public}@", log: self.logger(tag: tag), type: level.logLevel, logEntry.text)
+                self.notifyHooks(level: level, tag: tag, entry: logEntry)
             }
         }
     }

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -204,7 +204,7 @@ extension ZMLogTests {
         let message = "PANIC!"
         
         let expectation = self.expectation(description: "Log received")
-        let token = ZMSLog.addHook { (_level, _tag, _message) in
+        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(_message.text, message)
@@ -228,7 +228,7 @@ extension ZMLogTests {
         let level = ZMLogLevel_t.info
         let message = "PANIC!"
         
-        let token = ZMSLog.addHook { (_level, _tag, _message) in
+        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(_message.text, message)
@@ -252,7 +252,7 @@ extension ZMLogTests {
         let message = "PANIC!"
         
         let expectation = self.expectation(description: "Log received")
-        let token = ZMSLog.addHook { (_level, _tag, _message) in
+        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(_message.text, message)
@@ -276,7 +276,7 @@ extension ZMLogTests {
         let level = ZMLogLevel_t.debug
         let message = "PANIC!"
         
-        let token = ZMSLog.addHook { (_level, _tag, _message) in
+        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(_message.text, message)
@@ -301,7 +301,7 @@ extension ZMLogTests {
         let message = "PANIC!"
         
         let expectation = self.expectation(description: "Log received")
-        let token = ZMSLog.addHook { (_level, _tag, _message) in
+        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(_message.text, message)
@@ -325,7 +325,7 @@ extension ZMLogTests {
         let tag = "Network"
         let message = "PANIC!"
 
-        let token = ZMSLog.addHook { (_level, _tag, _message) in
+        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
             XCTFail()
         }
         ZMSLog.removeLogHook(token: token)
@@ -342,7 +342,7 @@ extension ZMLogTests {
         let tag = "Network"
         let message = "PANIC!"
         
-        let _ = ZMSLog.addHook { (_level, _tag, _message) in
+        let _ = ZMSLog.addMessageHook { (_level, _tag, _message) in
             XCTFail()
         }
         ZMSLog.removeAllLogHooks()
@@ -362,13 +362,13 @@ extension ZMLogTests {
         let expectation1 = self.expectation(description: "Log received")
         let expectation2 = self.expectation(description: "Log received")
 
-        let token1 = ZMSLog.addHook { (_level, _tag, _message) in
+        let token1 = ZMSLog.addMessageHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(_message.text, message)
             expectation1.fulfill()
         }
-        let token2 = ZMSLog.addHook { (_level, _tag, _message) in
+        let token2 = ZMSLog.addMessageHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(_message.text, message)
@@ -384,6 +384,30 @@ extension ZMLogTests {
         // AFTER
         ZMSLog.removeLogHook(token: token1)
         ZMSLog.removeLogHook(token: token2)
+    }
+
+    func testThatLogHookIsCalledWithDeprecatedAPI() {
+        // GIVEN
+        let tag = "Network"
+        let level = ZMLogLevel_t.warn
+        let message = "PANIC!"
+
+        let expectation = self.expectation(description: "Log received")
+        let token = ZMSLog.addHook { (_level, _tag, _message) in
+            XCTAssertEqual(level, _level)
+            XCTAssertEqual(tag, _tag)
+            XCTAssertEqual(_message, message)
+            expectation.fulfill()
+        }
+
+        // WHEN
+        ZMSLog(tag: tag).warn(message)
+
+        // THEN
+        self.waitForExpectations(timeout: 0.5)
+
+        // AFTER
+        ZMSLog.removeLogHook(token: token)
     }
 }
 

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -204,10 +204,10 @@ extension ZMLogTests {
         let message = "PANIC!"
         
         let expectation = self.expectation(description: "Log received")
-        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(_message.text, message)
+            XCTAssertEqual(entry.text, message)
             expectation.fulfill()
         }
         
@@ -228,10 +228,10 @@ extension ZMLogTests {
         let level = ZMLogLevel_t.info
         let message = "PANIC!"
         
-        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(_message.text, message)
+            XCTAssertEqual(entry.text, message)
         }
         
         // WHEN
@@ -252,10 +252,10 @@ extension ZMLogTests {
         let message = "PANIC!"
         
         let expectation = self.expectation(description: "Log received")
-        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(_message.text, message)
+            XCTAssertEqual(entry.text, message)
             expectation.fulfill()
         }
         
@@ -276,10 +276,10 @@ extension ZMLogTests {
         let level = ZMLogLevel_t.debug
         let message = "PANIC!"
         
-        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(_message.text, message)
+            XCTAssertEqual(entry.text, message)
             XCTFail()
         }
         
@@ -301,10 +301,10 @@ extension ZMLogTests {
         let message = "PANIC!"
         
         let expectation = self.expectation(description: "Log received")
-        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(_message.text, message)
+            XCTAssertEqual(entry.text, message)
             expectation.fulfill()
         }
         
@@ -325,7 +325,7 @@ extension ZMLogTests {
         let tag = "Network"
         let message = "PANIC!"
 
-        let token = ZMSLog.addMessageHook { (_level, _tag, _message) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
             XCTFail()
         }
         ZMSLog.removeLogHook(token: token)
@@ -342,7 +342,7 @@ extension ZMLogTests {
         let tag = "Network"
         let message = "PANIC!"
         
-        let _ = ZMSLog.addMessageHook { (_level, _tag, _message) in
+        let _ = ZMSLog.addEntryHook { (_level, _tag, entry) in
             XCTFail()
         }
         ZMSLog.removeAllLogHooks()
@@ -362,16 +362,16 @@ extension ZMLogTests {
         let expectation1 = self.expectation(description: "Log received")
         let expectation2 = self.expectation(description: "Log received")
 
-        let token1 = ZMSLog.addMessageHook { (_level, _tag, _message) in
+        let token1 = ZMSLog.addEntryHook { (_level, _tag, entry) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(_message.text, message)
+            XCTAssertEqual(entry.text, message)
             expectation1.fulfill()
         }
-        let token2 = ZMSLog.addMessageHook { (_level, _tag, _message) in
+        let token2 = ZMSLog.addEntryHook { (_level, _tag, entry) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(_message.text, message)
+            XCTAssertEqual(entry.text, message)
             expectation2.fulfill()
         }
         

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -207,7 +207,7 @@ extension ZMLogTests {
         let token = ZMSLog.addHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(message, _message)
+            XCTAssertEqual(_message.text, message)
             expectation.fulfill()
         }
         
@@ -231,7 +231,7 @@ extension ZMLogTests {
         let token = ZMSLog.addHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(message, _message)
+            XCTAssertEqual(_message.text, message)
         }
         
         // WHEN
@@ -255,7 +255,7 @@ extension ZMLogTests {
         let token = ZMSLog.addHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(message, _message)
+            XCTAssertEqual(_message.text, message)
             expectation.fulfill()
         }
         
@@ -279,7 +279,7 @@ extension ZMLogTests {
         let token = ZMSLog.addHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(message, _message)
+            XCTAssertEqual(_message.text, message)
             XCTFail()
         }
         
@@ -304,7 +304,7 @@ extension ZMLogTests {
         let token = ZMSLog.addHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(message, _message)
+            XCTAssertEqual(_message.text, message)
             expectation.fulfill()
         }
         
@@ -365,13 +365,13 @@ extension ZMLogTests {
         let token1 = ZMSLog.addHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(message, _message)
+            XCTAssertEqual(_message.text, message)
             expectation1.fulfill()
         }
         let token2 = ZMSLog.addHook { (_level, _tag, _message) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
-            XCTAssertEqual(message, _message)
+            XCTAssertEqual(_message.text, message)
             expectation2.fulfill()
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some log messages would be displayed in the log in such a way that there seems to be a gap between events – for example, the timestamp would make it seem that the event happened 4 seconds after when it actually happened.

### Causes

When logging the message to disk, we prepend the current date to the message. However, the current date at that time of saving the log to disk is different from the current date when the event actually happened, because logging is done asynchronously.

### Solutions

Save the timestamp of the log message at the moment we enqueue its logging, instead of using the current date at the time of saving to disk.