### PR TITLE
Public logging

### DIFF
--- a/Source/SafeForLoggingStringConvertible.swift
+++ b/Source/SafeForLoggingStringConvertible.swift
@@ -25,24 +25,18 @@ public protocol SafeForLoggingStringConvertible {
     var safeForLoggingDescription: String { get }
 }
 
-extension String: SafeForLoggingStringConvertible { public var safeForLoggingDescription: String { return self } }
-extension Int: SafeForLoggingStringConvertible { public var safeForLoggingDescription: String { return String(describing: self) } }
-extension Float: SafeForLoggingStringConvertible { public var safeForLoggingDescription: String { return String(describing: self) } }
-extension Double: SafeForLoggingStringConvertible { public var safeForLoggingDescription: String { return String(describing: self) } }
+public struct SafeValueForLogging<T: CustomStringConvertible>: SafeForLoggingStringConvertible {
+    public let value: T
+    public init(_ value: T) {
+        self.value = value
+    }
+    public var safeForLoggingDescription: String {
+        return value.description
+    }
+}
 
 extension Array: SafeForLoggingStringConvertible where Array.Element: SafeForLoggingStringConvertible {
     public var safeForLoggingDescription: String {
-        // This will print array of Ints as [1, 2, 3] instead of converting them to strings like this ["1", "2", "3"]
-        if let ints = self as? [Int] {
-            return String(describing: ints)
-        }
-        if let floats = self as? [Int] {
-            return String(describing: floats)
-        }
-        if let doubles = self as? [Int] {
-            return String(describing: doubles)
-        }
-        
         return String(describing: map { $0.safeForLoggingDescription} )
     }
 }

--- a/Source/SafeForLoggingStringConvertible.swift
+++ b/Source/SafeForLoggingStringConvertible.swift
@@ -1,0 +1,59 @@
+////
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Object can implement this protocol to allow creating the privacy-enabled object description.
+/// Things to consider when implementing is to exclude any kind of personal information from the object description:
+/// No user name, login, email, etc., or any kind of backend object ID.
+public protocol SafeForLoggingStringConvertible {
+    var safeForLoggingDescription: String { get }
+}
+
+extension String: SafeForLoggingStringConvertible { public var safeForLoggingDescription: String { return self } }
+extension Int: SafeForLoggingStringConvertible { public var safeForLoggingDescription: String { return String(describing: self) } }
+extension Float: SafeForLoggingStringConvertible { public var safeForLoggingDescription: String { return String(describing: self) } }
+extension Double: SafeForLoggingStringConvertible { public var safeForLoggingDescription: String { return String(describing: self) } }
+
+extension Array: SafeForLoggingStringConvertible where Array.Element: SafeForLoggingStringConvertible {
+    public var safeForLoggingDescription: String {
+        // This will print array of Ints as [1, 2, 3] instead of converting them to strings like this ["1", "2", "3"]
+        if let ints = self as? [Int] {
+            return String(describing: ints)
+        }
+        if let floats = self as? [Int] {
+            return String(describing: floats)
+        }
+        if let doubles = self as? [Int] {
+            return String(describing: doubles)
+        }
+        
+        return String(describing: map { $0.safeForLoggingDescription} )
+    }
+}
+
+extension Dictionary: SafeForLoggingStringConvertible where Key: SafeForLoggingStringConvertible, Value: SafeForLoggingStringConvertible {
+    public var safeForLoggingDescription: String {
+        let result = enumerated().map { (_, element) in
+            return (element.key.safeForLoggingDescription, element.value.safeForLoggingDescription)
+        }
+        
+        let dictionary = Dictionary<String, String>(uniqueKeysWithValues: result)
+        return String(describing: dictionary)
+    }
+}

--- a/Source/SanitizedString.swift
+++ b/Source/SanitizedString.swift
@@ -18,11 +18,11 @@
 
 import Foundation
 
-/// Object can implement `PrivateStringConvertible` to allow creating the privacy-enabled object description.
+/// Object can implement this protocol to allow creating the privacy-enabled object description.
 /// Things to consider when implementing is to exclude any kind of personal information from the object description:
 /// No user name, login, email, etc., or any kind of backend object ID.
-public protocol PrivateStringConvertible {
-    var privateDescription: String { get }
+public protocol SafeForLoggingStringConvertible {
+    var safeForLoggingDescription: String { get }
 }
 
 public struct SanitizedString: Equatable {
@@ -51,8 +51,8 @@ extension SanitizedString: StringInterpolationProtocol {
         value += literal
     }
     
-    public mutating func appendInterpolation<T: PrivateStringConvertible>(_ x: T) {
-        value += x.privateDescription
+    public mutating func appendInterpolation<T: SafeForLoggingStringConvertible>(_ x: T) {
+        value += x.safeForLoggingDescription
     }
 }
 

--- a/Source/SanitizedString.swift
+++ b/Source/SanitizedString.swift
@@ -1,0 +1,63 @@
+////
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Object can implement `PrivateStringConvertible` to allow creating the privacy-enabled object description.
+/// Things to consider when implementing is to exclude any kind of personal information from the object description:
+/// No user name, login, email, etc., or any kind of backend object ID.
+public protocol PrivateStringConvertible {
+    var privateDescription: String { get }
+}
+
+public struct SanitizedString: Equatable {
+    var value: String
+}
+
+extension SanitizedString: ExpressibleByStringLiteral {
+    public init(stringLiteral value: StringLiteralType) {
+        self.value = value
+    }
+}
+
+extension SanitizedString: ExpressibleByStringInterpolation {
+    public init(stringInterpolation: SanitizedString) {
+        self.value = stringInterpolation.value
+    }
+}
+
+extension SanitizedString: StringInterpolationProtocol {
+    
+    public init(literalCapacity: Int, interpolationCount: Int) {
+        self.value = ""
+    }
+    
+    public mutating func appendLiteral(_ literal: StringLiteralType) {
+        value += literal
+    }
+    
+    public mutating func appendInterpolation<T: PrivateStringConvertible>(_ x: T) {
+        value += x.privateDescription
+    }
+}
+
+extension SanitizedString: CustomStringConvertible {
+    public var description: String {
+        return value
+    }
+}

--- a/Source/SanitizedString.swift
+++ b/Source/SanitizedString.swift
@@ -18,13 +18,6 @@
 
 import Foundation
 
-/// Object can implement this protocol to allow creating the privacy-enabled object description.
-/// Things to consider when implementing is to exclude any kind of personal information from the object description:
-/// No user name, login, email, etc., or any kind of backend object ID.
-public protocol SafeForLoggingStringConvertible {
-    var safeForLoggingDescription: String { get }
-}
-
 public struct SanitizedString: Equatable {
     var value: String
 }

--- a/Source/SanitizedString.swift
+++ b/Source/SanitizedString.swift
@@ -44,8 +44,8 @@ extension SanitizedString: StringInterpolationProtocol {
         value += literal
     }
     
-    public mutating func appendInterpolation<T: SafeForLoggingStringConvertible>(_ x: T) {
-        value += x.safeForLoggingDescription
+    public mutating func appendInterpolation<T: SafeForLoggingStringConvertible>(_ x: T?) {
+        value += x?.safeForLoggingDescription ?? "nil"
     }
 }
 

--- a/Source/ZMSAsserts.swift
+++ b/Source/ZMSAsserts.swift
@@ -19,13 +19,6 @@
 
 import Foundation
 
-/// Object can implement `PrivateStringConvertible` to allow creating the privacy-enabled object description.
-/// Things to consider when implementing is to exclude any kind of personal information from the object description:
-/// No user name, login, email, etc., or any kind of backend object ID.
-public protocol PrivateStringConvertible {
-    var privateDescription: String { get }
-}
-
 /// Reports an error and terminates the application
 public func fatal(_ message: String, file: String = #file, line: Int = #line) -> Never  {
     ZMAssertionDump_NSString("Swift assertion", file, Int32(line), message)

--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -27,7 +27,7 @@ extension ZMSLog {
         logQueue.sync {
             if recordingToken == nil {
                 recordingToken = self.nonLockingAddEntryHook(logHook: { (level, tag, entry) -> (Void) in
-                    guard isInternal || level != .error else { return }
+                    guard isInternal || level == .public else { return }
                     let tagString = tag.flatMap { "[\($0)] "} ?? ""
                     let date = dateFormatter.string(from: entry.timestamp)
                     ZMSLog.appendToCurrentLog("\(date): [\(level.rawValue)] \(tagString)\(entry.text)\n")

--- a/Source/ZMSLog.swift
+++ b/Source/ZMSLog.swift
@@ -78,6 +78,11 @@ public class ZMSLogEntry: NSObject {
 // MARK: - Emit logs
 extension ZMSLog {
     
+    public func safePublic(_ message: @autoclosure () -> SanitizedString, file: String = #file, line: UInt = #line) {
+        let entry = ZMSLogEntry(text: message().value, timestamp: Date())
+        ZMSLog.logEntry(entry, level: .public, tag: tag, file: file, line: line)
+    }
+    
     public func error(_ message: @autoclosure () -> String, file: String = #file, line: UInt = #line) {
         ZMSLog.logWithLevel(.error, message: message(), tag: self.tag, file: file, line:line)
     }
@@ -89,10 +94,6 @@ extension ZMSLog {
     }
     public func debug(_ message: @autoclosure () -> String, file: String = #file, line: UInt = #line) {
         ZMSLog.logWithLevel(.debug, message: message(), tag: self.tag, file: file, line:line)
-    }
- 
-    public func publicLog(_ message: @autoclosure () -> SanitizedString, file: String = #file, line: UInt = #line) {
-        ZMSLog.logWithLevel(.error, message: "\(message())", tag: self.tag, file: file, line:line)
     }
 }
 
@@ -191,14 +192,14 @@ extension ZMLogLevel_t {
     @available(iOS 10.0, *)
     var logLevel: OSLogType {
         switch self {
-        case .error:
-            return .error
-        case .warn:
+        case .public, .error, .warn:
             return .error
         case .info:
             return .info
         case .debug:
             return .debug
+        @unknown default:
+            return .error
         }
     }
 }
@@ -206,17 +207,20 @@ extension ZMLogLevel_t {
 // MARK: - Internal stuff
 extension ZMSLog {
     
-    /// Log only if this log level is enabled for the tag, or no tag is set
     @objc static public func logWithLevel(_ level: ZMLogLevel_t, message:  @autoclosure () -> String, tag: String?, file: String = #file, line: UInt = #line) {
-        let logEntry = ZMSLogEntry(text: message(), timestamp: Date())
+        let entry = ZMSLogEntry(text: message(), timestamp: Date())
+        logEntry(entry, level: level, tag: tag, file: file, line: line)
+    }
+    
+    static private func logEntry(_ entry: ZMSLogEntry, level: ZMLogLevel_t, tag: String?, file: String = #file, line: UInt = #line) {
         logQueue.async {
             if let tag = tag {
                 self.register(tag: tag)
             }
         
             if tag == nil || level.rawValue <= ZMSLog.getLevelNoLock(tag: tag!).rawValue {
-                os_log("%{public}@", log: self.logger(tag: tag), type: level.logLevel, logEntry.text)
-                self.notifyHooks(level: level, tag: tag, entry: logEntry)
+                os_log("%{public}@", log: self.logger(tag: tag), type: level.logLevel, entry.text)
+                self.notifyHooks(level: level, tag: tag, entry: entry)
             }
         }
     }

--- a/Source/ZMSLog.swift
+++ b/Source/ZMSLog.swift
@@ -90,6 +90,10 @@ extension ZMSLog {
     public func debug(_ message: @autoclosure () -> String, file: String = #file, line: UInt = #line) {
         ZMSLog.logWithLevel(.debug, message: message(), tag: self.tag, file: file, line:line)
     }
+ 
+    public func publicLog(_ message: @autoclosure () -> SanitizedString, file: String = #file, line: UInt = #line) {
+        ZMSLog.logWithLevel(.error, message: "\(message())", tag: self.tag, file: file, line:line)
+    }
 }
 
 // MARK: - Conditional execution

--- a/Source/ZMSLogging.h
+++ b/Source/ZMSLogging.h
@@ -52,7 +52,7 @@ typedef NS_ENUM(int8_t, ZMLogLevel_t) {
  You can set a (symbolic) breakpoint at ZMLogDebugger to stop automatically when a warning or error level message is logged.
  
  **/
-#define ZMLogPublic(format, ...) ZMLogWithLevel(ZMLogLevelPublic, format, ##__VA_ARGS__)
+#define ZMLogPublic(format, ...) ZMLogWithLevelAndTag(ZMLogLevelPublic, ZMLogTag, format, ##__VA_ARGS__)
 #define ZMLogError(format, ...) ZMLogWithLevel(ZMLogLevelError, format, ##__VA_ARGS__)
 #define ZMLogWarn(format, ...) ZMLogWithLevel(ZMLogLevelWarn, format, ##__VA_ARGS__)
 #define ZMLogInfo(format, ...) ZMLogWithLevelAndTag(ZMLogLevelInfo, ZMLogTag, format, ##__VA_ARGS__)

--- a/Source/ZMSLogging.h
+++ b/Source/ZMSLogging.h
@@ -22,7 +22,8 @@
 
 /// Log levels
 typedef NS_ENUM(int8_t, ZMLogLevel_t) {
-    ZMLogLevelError = 0,
+    ZMLogLevelPublic = 0,
+    ZMLogLevelError,
     ZMLogLevelWarn,
     ZMLogLevelInfo,
     ZMLogLevelDebug,
@@ -51,7 +52,7 @@ typedef NS_ENUM(int8_t, ZMLogLevel_t) {
  You can set a (symbolic) breakpoint at ZMLogDebugger to stop automatically when a warning or error level message is logged.
  
  **/
-
+#define ZMLogPublic(format, ...) ZMLogWithLevel(ZMLogLevelPublic, format, ##__VA_ARGS__)
 #define ZMLogError(format, ...) ZMLogWithLevel(ZMLogLevelError, format, ##__VA_ARGS__)
 #define ZMLogWarn(format, ...) ZMLogWithLevel(ZMLogLevelWarn, format, ##__VA_ARGS__)
 #define ZMLogInfo(format, ...) ZMLogWithLevelAndTag(ZMLogLevelInfo, ZMLogTag, format, ##__VA_ARGS__)

--- a/Tests/SanitizedLogTests.swift
+++ b/Tests/SanitizedLogTests.swift
@@ -1,0 +1,64 @@
+////
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+
+import XCTest
+@testable import WireSystem
+
+struct Item {
+    var name: String
+    var age: Int
+}
+
+extension Item: PrivateStringConvertible {
+    static var redacted = "<redacted>"
+    
+    var privateDescription: String {
+        return Item.redacted
+    }
+}
+
+
+class SanitizedLogTests: XCTestCase {
+    
+    var item: Item!
+    
+    override func setUp() {
+        super.setUp()
+        item = Item(name: "top-secret", age: 99)
+    }
+    
+    override func tearDown() {
+        item = nil
+        super.tearDown()
+    }
+    
+    func testInterpolation() {
+        let interpolated: SanitizedString = "\(item)"
+        let redacted: SanitizedString = "<redacted>"
+        XCTAssertEqual(redacted, interpolated)
+    }
+    
+    func testInterpolationWithLiterals() {
+        let interpolated: SanitizedString = "some \(item) item"
+        let result = SanitizedString(value: "some \(Item.redacted) item")
+        XCTAssertEqual(result, interpolated)
+    }    
+}

--- a/Tests/SanitizedLogTests.swift
+++ b/Tests/SanitizedLogTests.swift
@@ -27,10 +27,10 @@ struct Item {
     var age: Int
 }
 
-extension Item: PrivateStringConvertible {
+extension Item: SafeForLoggingStringConvertible {
     static var redacted = "<redacted>"
     
-    var privateDescription: String {
+    var safeForLoggingDescription: String {
         return Item.redacted
     }
 }

--- a/Tests/SanitizedLogTests.swift
+++ b/Tests/SanitizedLogTests.swift
@@ -58,7 +58,7 @@ class SanitizedLogTests: XCTestCase {
     
     func testInterpolationWithLiterals() {
         let interpolated: SanitizedString = "some \(item) item"
-        let result = SanitizedString(value: "some \(Item.redacted) item")
+        let result = SanitizedString(stringLiteral: "some \(Item.redacted) item")
         XCTAssertEqual(result, interpolated)
     }    
 }

--- a/Tests/SanitizedStringTests.swift
+++ b/Tests/SanitizedStringTests.swift
@@ -66,40 +66,44 @@ class SanitizedStringTests: XCTestCase {
 extension SanitizedStringTests {
     func testString() {
         let sut = "some"
-        let result: SanitizedString = "\(sut)"
+        let value = SafeValueForLogging(sut)
+        let result: SanitizedString = "\(value)"
         XCTAssertEqual(sut, result.value)
     }
     
     func testInt() {
         let sut = 12
-        let result: SanitizedString = "\(sut)"
+        let value = SafeValueForLogging(sut)
+        let result: SanitizedString = "\(value)"
         XCTAssertEqual(String(sut), result.value)
     }
     
     func testFloat() {
         let sut: Float = 12.1
-        let result: SanitizedString = "\(sut)"
+        let value = SafeValueForLogging(sut)
+        let result: SanitizedString = "\(value)"
         XCTAssertEqual(String(sut), result.value)
     }
     
     func testDouble() {
         let sut: Double = 12.1
-        let result: SanitizedString = "\(sut)"
+        let value = SafeValueForLogging(sut)
+        let result: SanitizedString = "\(value)"
         XCTAssertEqual(String(sut), result.value)
     }
     
     func testArray() {
         let sut = [1, 2, 3]
-        let result: SanitizedString = "\(sut)"
+        let value = SafeValueForLogging(sut)
+        let result: SanitizedString = "\(value)"
         XCTAssertEqual(String(describing: sut), result.value)
     }
     
     func testDictionary() {
         let sut = ["some" : 2]
-        let result: SanitizedString = "\(sut)"
+        let value = SafeValueForLogging(sut)
+        let result: SanitizedString = "\(value)"
         
-        // All keys and values in the dictionary will be converted to strings, so 1 will become "1"
-        let converted = sut.mapValues { String($0) }
-        XCTAssertEqual(String(describing: converted), result.value)
+        XCTAssertEqual(String(describing: sut), result.value)
     }
 }

--- a/Tests/SanitizedStringTests.swift
+++ b/Tests/SanitizedStringTests.swift
@@ -106,4 +106,18 @@ extension SanitizedStringTests {
         
         XCTAssertEqual(String(describing: sut), result.value)
     }
+    
+    func testOptional_nil() {
+        let value: SafeValueForLogging<String>? = nil
+        let result: SanitizedString = "\(value)"
+        XCTAssertEqual("nil", result.value)
+    }
+    
+    func testOptional_notNil() {
+        let sut = "something"
+        let value: SafeValueForLogging<String>? = SafeValueForLogging(sut)
+        let result: SanitizedString = "\(value)"
+        
+        XCTAssertEqual(String(describing: sut), result.value)
+    }
 }

--- a/Tests/SanitizedStringTests.swift
+++ b/Tests/SanitizedStringTests.swift
@@ -36,7 +36,7 @@ extension Item: SafeForLoggingStringConvertible {
 }
 
 
-class SanitizedLogTests: XCTestCase {
+class SanitizedStringTests: XCTestCase {
     
     var item: Item!
     
@@ -60,5 +60,46 @@ class SanitizedLogTests: XCTestCase {
         let interpolated: SanitizedString = "some \(item) item"
         let result = SanitizedString(stringLiteral: "some \(Item.redacted) item")
         XCTAssertEqual(result, interpolated)
-    }    
+    }
+}
+
+extension SanitizedStringTests {
+    func testString() {
+        let sut = "some"
+        let result: SanitizedString = "\(sut)"
+        XCTAssertEqual(sut, result.value)
+    }
+    
+    func testInt() {
+        let sut = 12
+        let result: SanitizedString = "\(sut)"
+        XCTAssertEqual(String(sut), result.value)
+    }
+    
+    func testFloat() {
+        let sut: Float = 12.1
+        let result: SanitizedString = "\(sut)"
+        XCTAssertEqual(String(sut), result.value)
+    }
+    
+    func testDouble() {
+        let sut: Double = 12.1
+        let result: SanitizedString = "\(sut)"
+        XCTAssertEqual(String(sut), result.value)
+    }
+    
+    func testArray() {
+        let sut = [1, 2, 3]
+        let result: SanitizedString = "\(sut)"
+        XCTAssertEqual(String(describing: sut), result.value)
+    }
+    
+    func testDictionary() {
+        let sut = ["some" : 2]
+        let result: SanitizedString = "\(sut)"
+        
+        // All keys and values in the dictionary will be converted to strings, so 1 will become "1"
+        let converted = sut.mapValues { String($0) }
+        XCTAssertEqual(String(describing: converted), result.value)
+    }
 }

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -425,9 +425,9 @@ extension ZMLogTests {
     }
     
     func testThatItRecordsPublicLogs() {
-        struct Item: PrivateStringConvertible {
+        struct Item: SafeForLoggingStringConvertible {
             var name: String
-            var privateDescription: String {
+            var safeForLoggingDescription: String {
                 return "hidden"
             }
         }

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -420,8 +420,8 @@ extension ZMLogTests {
         let lines = getLinesFromCurrentLog()
 
         XCTAssertEqual(lines.count, 2)
-        XCTAssertTrue(lines.first!.hasSuffix("[0] [foo] PANIC"))
-        XCTAssertTrue(lines.last!.hasSuffix("[0] [foo] HELP"))
+        XCTAssertTrue(lines.first!.hasSuffix("[1] [foo] PANIC"))
+        XCTAssertTrue(lines.last!.hasSuffix("[1] [foo] HELP"))
     }
     
     func testThatItRecordsPublicLogs() {
@@ -438,7 +438,7 @@ extension ZMLogTests {
         ZMSLog.startRecording()
         
         // WHEN
-        sut.publicLog("Item: \(item)")
+        sut.safePublic("Item: \(item)")
         
         Thread.sleep(forTimeInterval: 0.2)
         
@@ -523,6 +523,8 @@ extension ZMLogTests {
         //when
         ZMSLog.startRecording(isInternal: false)
         
+        sut.safePublic("PUBLIC")
+        
         ZMSLog.set(level: .error, tag: tag)
         sut.error("ERROR")
         
@@ -540,11 +542,8 @@ extension ZMLogTests {
         let lines = getLinesFromCurrentLog()
         
         //then
-        XCTAssertEqual(lines.count, 3)
+        XCTAssertEqual(lines.count, 1)
         XCTAssertFalse(lines.first!.hasSuffix("[0] [tag] ERROR"))
-        XCTAssertTrue(lines[0].hasSuffix("[1] [tag] WARN"))
-        XCTAssertTrue(lines[1].hasSuffix("[2] [tag] INFO"))
-        XCTAssertTrue(lines[2].hasSuffix("[3] [tag] DEBUG"))
     }
     
     func testThatItSavesAllLevelsOnInternals() {
@@ -556,6 +555,8 @@ extension ZMLogTests {
         //when
         ZMSLog.startRecording(isInternal: true)
         
+        sut.safePublic("PUBLIC")
+        
         ZMSLog.set(level: .error, tag: tag)
         sut.error("ERROR")
         
@@ -573,11 +574,12 @@ extension ZMLogTests {
         let lines = getLinesFromCurrentLog()
         
         //then
-        XCTAssertEqual(lines.count, 4)
-        XCTAssertTrue(lines[0].hasSuffix("[0] [tag] ERROR"))
-        XCTAssertTrue(lines[1].hasSuffix("[1] [tag] WARN"))
-        XCTAssertTrue(lines[2].hasSuffix("[2] [tag] INFO"))
-        XCTAssertTrue(lines[3].hasSuffix("[3] [tag] DEBUG"))
+        XCTAssertEqual(lines.count, 5)
+        XCTAssertTrue(lines[0].hasSuffix("[0] [tag] PUBLIC"))
+        XCTAssertTrue(lines[1].hasSuffix("[1] [tag] ERROR"))
+        XCTAssertTrue(lines[2].hasSuffix("[2] [tag] WARN"))
+        XCTAssertTrue(lines[3].hasSuffix("[3] [tag] INFO"))
+        XCTAssertTrue(lines[4].hasSuffix("[4] [tag] DEBUG"))
     }
     
     

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -424,6 +424,31 @@ extension ZMLogTests {
         XCTAssertTrue(lines.last!.hasSuffix("[0] [foo] HELP"))
     }
     
+    func testThatItRecordsPublicLogs() {
+        struct Item: PrivateStringConvertible {
+            var name: String
+            var privateDescription: String {
+                return "hidden"
+            }
+        }
+        
+        // GIVEN
+        let sut = ZMSLog(tag: "foo")
+        let item = Item(name: "Secret")
+        ZMSLog.startRecording()
+        
+        // WHEN
+        sut.publicLog("Item: \(item)")
+        
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        // THEN
+        let lines = getLinesFromCurrentLog()
+        
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertTrue(lines.first!.hasSuffix("[0] [foo] Item: hidden"))
+    }
+    
     func testThatItDiscardsLogsWhenStopped() {
         
         // GIVEN

--- a/WireSystem.xcodeproj/project.pbxproj
+++ b/WireSystem.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		8701221920F641BE001E6342 /* CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8701221720F641A4001E6342 /* CacheTests.swift */; };
 		D59F3A1B206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59F3A1A206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift */; };
 		D59F3A1D206A47E80023474F /* DispatchQueueHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */; };
+		F1670FAE22A7C5F500BC6811 /* SanitizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1670FAD22A7C5F500BC6811 /* SanitizedString.swift */; };
+		F1670FB022A7C7D800BC6811 /* SanitizedLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1670FAF22A7C7D800BC6811 /* SanitizedLogTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -112,6 +114,8 @@
 		8701221720F641A4001E6342 /* CacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheTests.swift; sourceTree = "<group>"; };
 		D59F3A1A206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+ZMSDispatchGroup.swift"; sourceTree = "<group>"; };
 		D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueHelperTests.swift; sourceTree = "<group>"; };
+		F1670FAD22A7C5F500BC6811 /* SanitizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SanitizedString.swift; sourceTree = "<group>"; };
+		F1670FAF22A7C7D800BC6811 /* SanitizedLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SanitizedLogTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -183,6 +187,7 @@
 				5473E7C71B31A95A00C6A937 /* WireSystem.h */,
 				096A3A1C1B67CEF700565001 /* ZMSLogging.h */,
 				096A3A1D1B67CEF700565001 /* ZMSLogging.m */,
+				F1670FAD22A7C5F500BC6811 /* SanitizedString.swift */,
 				096A3A1E1B67CEF700565001 /* ZMSLog.swift */,
 				54DB81621DBF66CF00AF495D /* ZMSLog+Levels.swift */,
 				54D573691DBFBAFA00D6C2C4 /* ZMSLog+Recording.swift */,
@@ -229,6 +234,7 @@
 				54A327391B99A3840004EB95 /* ZMLoggingTests.m */,
 				5457426B1BA9C50C0009409B /* ZMDefinesTest.m */,
 				54A3273B1B99C04F0004EB95 /* ZMLogTests.swift */,
+				F1670FAF22A7C7D800BC6811 /* SanitizedLogTests.swift */,
 				D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */,
 				54DB81661DBFB16700AF495D /* CircularArrayTests.swift */,
 				54DAE8FC1BA83B01009403F8 /* Test-Bridging.h */,
@@ -386,6 +392,7 @@
 				096A3A211B67CEF700565001 /* ZMSLogging.m in Sources */,
 				54DB81651DBFACE800AF495D /* CircularArray.swift in Sources */,
 				16962EDE20221F970069D88D /* ZMSLogNotifications.m in Sources */,
+				F1670FAE22A7C5F500BC6811 /* SanitizedString.swift in Sources */,
 				54DB81631DBF66CF00AF495D /* ZMSLog+Levels.swift in Sources */,
 				54FF9F121C48F67300B29ACE /* ZMSTimePoint.m in Sources */,
 				54D5736A1DBFBAFA00D6C2C4 /* ZMSLog+Recording.swift in Sources */,
@@ -402,6 +409,7 @@
 				54C5DF8A1BBADA3D00DCFC95 /* ZMSDispatchGroupTests.m in Sources */,
 				54180BDE1F459DFF0020D2BD /* MemoryReferenceDebuggerTests.m in Sources */,
 				8701221920F641BE001E6342 /* CacheTests.swift in Sources */,
+				F1670FB022A7C7D800BC6811 /* SanitizedLogTests.swift in Sources */,
 				54A3273C1B99C04F0004EB95 /* ZMLogTests.swift in Sources */,
 				54FF9F161C4914D100B29ACE /* ZMSTestDetectionTests.m in Sources */,
 				D59F3A1D206A47E80023474F /* DispatchQueueHelperTests.swift in Sources */,

--- a/WireSystem.xcodeproj/project.pbxproj
+++ b/WireSystem.xcodeproj/project.pbxproj
@@ -47,7 +47,8 @@
 		D59F3A1B206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59F3A1A206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift */; };
 		D59F3A1D206A47E80023474F /* DispatchQueueHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */; };
 		F1670FAE22A7C5F500BC6811 /* SanitizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1670FAD22A7C5F500BC6811 /* SanitizedString.swift */; };
-		F1670FB022A7C7D800BC6811 /* SanitizedLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1670FAF22A7C7D800BC6811 /* SanitizedLogTests.swift */; };
+		F1670FB022A7C7D800BC6811 /* SanitizedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1670FAF22A7C7D800BC6811 /* SanitizedStringTests.swift */; };
+		F19E554522AA8748005C792D /* SafeForLoggingStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E554422AA8748005C792D /* SafeForLoggingStringConvertible.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,7 +116,8 @@
 		D59F3A1A206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+ZMSDispatchGroup.swift"; sourceTree = "<group>"; };
 		D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueHelperTests.swift; sourceTree = "<group>"; };
 		F1670FAD22A7C5F500BC6811 /* SanitizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SanitizedString.swift; sourceTree = "<group>"; };
-		F1670FAF22A7C7D800BC6811 /* SanitizedLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SanitizedLogTests.swift; sourceTree = "<group>"; };
+		F1670FAF22A7C7D800BC6811 /* SanitizedStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SanitizedStringTests.swift; sourceTree = "<group>"; };
+		F19E554422AA8748005C792D /* SafeForLoggingStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeForLoggingStringConvertible.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -188,6 +190,7 @@
 				096A3A1C1B67CEF700565001 /* ZMSLogging.h */,
 				096A3A1D1B67CEF700565001 /* ZMSLogging.m */,
 				F1670FAD22A7C5F500BC6811 /* SanitizedString.swift */,
+				F19E554422AA8748005C792D /* SafeForLoggingStringConvertible.swift */,
 				096A3A1E1B67CEF700565001 /* ZMSLog.swift */,
 				54DB81621DBF66CF00AF495D /* ZMSLog+Levels.swift */,
 				54D573691DBFBAFA00D6C2C4 /* ZMSLog+Recording.swift */,
@@ -234,7 +237,7 @@
 				54A327391B99A3840004EB95 /* ZMLoggingTests.m */,
 				5457426B1BA9C50C0009409B /* ZMDefinesTest.m */,
 				54A3273B1B99C04F0004EB95 /* ZMLogTests.swift */,
-				F1670FAF22A7C7D800BC6811 /* SanitizedLogTests.swift */,
+				F1670FAF22A7C7D800BC6811 /* SanitizedStringTests.swift */,
 				D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */,
 				54DB81661DBFB16700AF495D /* CircularArrayTests.swift */,
 				54DAE8FC1BA83B01009403F8 /* Test-Bridging.h */,
@@ -393,6 +396,7 @@
 				54DB81651DBFACE800AF495D /* CircularArray.swift in Sources */,
 				16962EDE20221F970069D88D /* ZMSLogNotifications.m in Sources */,
 				F1670FAE22A7C5F500BC6811 /* SanitizedString.swift in Sources */,
+				F19E554522AA8748005C792D /* SafeForLoggingStringConvertible.swift in Sources */,
 				54DB81631DBF66CF00AF495D /* ZMSLog+Levels.swift in Sources */,
 				54FF9F121C48F67300B29ACE /* ZMSTimePoint.m in Sources */,
 				54D5736A1DBFBAFA00D6C2C4 /* ZMSLog+Recording.swift in Sources */,
@@ -409,7 +413,7 @@
 				54C5DF8A1BBADA3D00DCFC95 /* ZMSDispatchGroupTests.m in Sources */,
 				54180BDE1F459DFF0020D2BD /* MemoryReferenceDebuggerTests.m in Sources */,
 				8701221920F641BE001E6342 /* CacheTests.swift in Sources */,
-				F1670FB022A7C7D800BC6811 /* SanitizedLogTests.swift in Sources */,
+				F1670FB022A7C7D800BC6811 /* SanitizedStringTests.swift in Sources */,
 				54A3273C1B99C04F0004EB95 /* ZMLogTests.swift in Sources */,
 				54FF9F161C4914D100B29ACE /* ZMSTestDetectionTests.m in Sources */,
 				D59F3A1D206A47E80023474F /* DispatchQueueHelperTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

We would like to add logs for public builds, but we need to avoid printing any sensitive data. Simply by printing for example `ZMUser` we could leak their email address.

### Solutions

Added a new method in our logging class - `publicLog()`. It accepts string literals (which we consider safe) and any object that implements `PrivateStringConvertible` protocol. It is a compile error if we try to pass regular object.

## Notes

We will have to add `PrivateStringConvertible` conformance for things like `URL` and `Data` in this framework.