### PR TITLE
Adding newline to log only if it does not have one

### DIFF
--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -30,7 +30,9 @@ extension ZMSLog {
                     guard isInternal || level == .public else { return }
                     let tagString = tag.flatMap { "[\($0)] "} ?? ""
                     let date = dateFormatter.string(from: entry.timestamp)
-                    ZMSLog.appendToCurrentLog("\(date): [\(level.rawValue)] \(tagString)\(entry.text)\n")
+                    // Add newline if it does not have it yet
+                    let text = entry.text.hasSuffix("\n") ? entry.text : entry.text + "\n"
+                    ZMSLog.appendToCurrentLog("\(date): [\(level.rawValue)] \(tagString)\(text)")
                 })
             }
         }

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -385,6 +385,23 @@ extension ZMLogTests {
         ZMSLog.removeLogHook(token: token1)
         ZMSLog.removeLogHook(token: token2)
     }
+    
+    func testThatItAppendsOnlyOneNewlineWhenLogEntryContainsNewline() {
+        // GIVEN
+        let sut = ZMSLog(tag: "foo")
+        ZMSLog.startRecording()
+        
+        // WHEN
+        sut.error("PANIC\n")
+        sut.error("HELP")
+        
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        // THEN
+        let lines = getLinesFromCurrentLog()
+
+        XCTAssertEqual(lines.count, 2)
+    }
 
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When logging something with a newline character at the end we would have an empty line in logs. This hurts readability.

### Causes

We would always append newline to each log entry.

### Solutions

Append newline only if it is missing.
