### PR TITLE
Fix: Enable logs when running the app

### DIFF
--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -27,7 +27,8 @@ extension ZMSLog {
         logQueue.sync {
             if recordingToken == nil {
                 recordingToken = self.nonLockingAddEntryHook(logHook: { (level, tag, entry) -> (Void) in
-                    guard isRunningSystemTests else { return }
+                    ///TODO: @Nicola some tests such as testThatItRecordsLogs checks about log files. If want to have logs when running the app, the condition should be isRunningSystemTests == false
+//                    guard !isRunningSystemTests else { return }
                     guard isInternal || level == .public else { return }
                     let tagString = tag.flatMap { "[\($0)] "} ?? ""
                     let date = dateFormatter.string(from: entry.timestamp)
@@ -65,4 +66,12 @@ extension ZMSLog {
         return path.contains("WireSystem Tests")
     }
     
+}
+
+extension String {
+    private static var dateFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS Z"
+        return df
+    }
 }

--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -67,11 +67,3 @@ extension ZMSLog {
     }
     
 }
-
-extension String {
-    private static var dateFormatter: DateFormatter {
-        let df = DateFormatter()
-        df.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS Z"
-        return df
-    }
-}


### PR DESCRIPTION
## What's new in this PR?

### Issues

No log is logged when running the app.

### Causes

After https://github.com/wireapp/wire-ios-system/pull/43, the logging is disabled since `isRunningSystemTests` == false when running the app.

### Solutions

Disable that line.

## Discussion
@nicorsm in `ZMLogTests.swift` we have some tests related to log files, should we make exceptions for those cases?

