### PR TITLE
Improve performance of logging to a file

### DIFF
--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -54,11 +54,11 @@ extension ZMSLog {
         }
     }
 
-    private static var dateFormatter: DateFormatter {
+    private static var dateFormatter: DateFormatter = {
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS Z"
         return df
-    }
+    }()
     
     private static var isRunningSystemTests: Bool {
         guard let path = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"]

--- a/Source/ZMSLog.swift
+++ b/Source/ZMSLog.swift
@@ -241,16 +241,15 @@ extension ZMSLog {
 
     static private func readFile(at url: URL) -> Data? {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        
+        try? handle.wr_synchronizeFile()
+        
         return handle.readDataToEndOfFile()
     }
     
-    @objc static public var previousLogPath: URL? {
-        return cachesDirectory?.appendingPathComponent("previous.log")
-    }
+    @objc static public let previousLogPath: URL? = cachesDirectory?.appendingPathComponent("previous.log")
     
-    @objc static public var currentLogPath: URL? {
-        return cachesDirectory?.appendingPathComponent("current.log")
-    }
+    @objc static public let currentLogPath: URL? = cachesDirectory?.appendingPathComponent("current.log")
     
     @objc public static func clearLogs() {
         guard let previousLogPath = previousLogPath, let currentLogPath = currentLogPath else { return }
@@ -294,6 +293,7 @@ extension ZMSLog {
     }
 
     static public func appendToCurrentLog(_ string: String) {
+        
         guard let currentLogURL = self.currentLogPath else { return }
         let currentLogPath = currentLogURL.path
 
@@ -314,7 +314,6 @@ extension ZMSLog {
 
             do {
                 try updatingHandle?.wr_write(data)
-                try updatingHandle?.wr_synchronizeFile()
             } catch {
                 updatingHandle = nil
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

If many logs are written this will block core data from saving. If there was a connecting call, which produces hundreds of log statements, then this could block the save call for several seconds.

### Causes

We are writing to disk on every log statement. 

### Solutions

Only flush the log file to disk before we are reading it.

## Notes

I also turned a few computed properties into static properties to avoid re-recreating them on every log statement.