### PR TITLE
Fix/lower public level logs

### DIFF
--- a/Source/ZMSLog+Recording.swift
+++ b/Source/ZMSLog+Recording.swift
@@ -26,10 +26,8 @@ extension ZMSLog {
     @objc public static func startRecording(isInternal: Bool = true) {
         logQueue.sync {
             if recordingToken == nil {
-                recordingToken = self.nonLockingAddEntryHook(logHook: { (level, tag, entry) -> (Void) in
-                    ///TODO: @Nicola some tests such as testThatItRecordsLogs checks about log files. If want to have logs when running the app, the condition should be isRunningSystemTests == false
-//                    guard !isRunningSystemTests else { return }
-                    guard isInternal || level == .public else { return }
+                recordingToken = self.nonLockingAddEntryHook(logHook: { (level, tag, entry, isSafe) -> (Void) in
+                    guard isInternal || isSafe else { return }
                     let tagString = tag.flatMap { "[\($0)] "} ?? ""
                     let date = dateFormatter.string(from: entry.timestamp)
                     // Add newline if it does not have it yet

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -457,13 +457,9 @@ extension ZMLogTests {
         // WHEN
         sut.safePublic("Item: \(item)")
         
-        Thread.sleep(forTimeInterval: 0.2)
-        
         // THEN
-        let lines = getLinesFromCurrentLog()
-        
-        XCTAssertEqual(lines.count, 0)
-        Thread.sleep(forTimeInterval: 0.2)
+        let currentLog = ZMSLog.currentLog
+        XCTAssertNil(currentLog)
     }
     
     func testThatItRecordsPublicLogsWhenLevelIsEnabled() {
@@ -627,11 +623,11 @@ extension ZMLogTests {
     }
     
     
-    func getLinesFromCurrentLog() -> [String] {
+    func getLinesFromCurrentLog(file: StaticString = #file, line: UInt = #line) -> [String] {
         
         guard let currentLog = ZMSLog.currentLog,
             let logContent = String(data: currentLog, encoding: .utf8) else {
-                XCTFail()
+                XCTFail(file: file, line: line)
                 return []
         }
         

--- a/Tests/ZMLogTests.swift
+++ b/Tests/ZMLogTests.swift
@@ -204,7 +204,7 @@ extension ZMLogTests {
         let message = "PANIC!"
         
         let expectation = self.expectation(description: "Log received")
-        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(entry.text, message)
@@ -228,7 +228,7 @@ extension ZMLogTests {
         let level = ZMLogLevel_t.info
         let message = "PANIC!"
         
-        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(entry.text, message)
@@ -252,7 +252,7 @@ extension ZMLogTests {
         let message = "PANIC!"
         
         let expectation = self.expectation(description: "Log received")
-        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(entry.text, message)
@@ -276,7 +276,7 @@ extension ZMLogTests {
         let level = ZMLogLevel_t.debug
         let message = "PANIC!"
         
-        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(entry.text, message)
@@ -301,7 +301,7 @@ extension ZMLogTests {
         let message = "PANIC!"
         
         let expectation = self.expectation(description: "Log received")
-        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(entry.text, message)
@@ -325,7 +325,7 @@ extension ZMLogTests {
         let tag = "Network"
         let message = "PANIC!"
 
-        let token = ZMSLog.addEntryHook { (_level, _tag, entry) in
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
             XCTFail()
         }
         ZMSLog.removeLogHook(token: token)
@@ -342,7 +342,7 @@ extension ZMLogTests {
         let tag = "Network"
         let message = "PANIC!"
         
-        let _ = ZMSLog.addEntryHook { (_level, _tag, entry) in
+        let _ = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
             XCTFail()
         }
         ZMSLog.removeAllLogHooks()
@@ -362,13 +362,13 @@ extension ZMLogTests {
         let expectation1 = self.expectation(description: "Log received")
         let expectation2 = self.expectation(description: "Log received")
 
-        let token1 = ZMSLog.addEntryHook { (_level, _tag, entry) in
+        let token1 = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(entry.text, message)
             expectation1.fulfill()
         }
-        let token2 = ZMSLog.addEntryHook { (_level, _tag, entry) in
+        let token2 = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
             XCTAssertEqual(level, _level)
             XCTAssertEqual(tag, _tag)
             XCTAssertEqual(entry.text, message)
@@ -441,7 +441,7 @@ extension ZMLogTests {
         XCTAssertTrue(lines.last!.hasSuffix("[1] [foo] HELP"))
     }
     
-    func testThatItRecordsPublicLogs() {
+    func testThatItDoesNotRecordsPublicLogsWhenLevelIsTooLow() {
         struct Item: SafeForLoggingStringConvertible {
             var name: String
             var safeForLoggingDescription: String {
@@ -462,8 +462,34 @@ extension ZMLogTests {
         // THEN
         let lines = getLinesFromCurrentLog()
         
+        XCTAssertEqual(lines.count, 0)
+        Thread.sleep(forTimeInterval: 0.2)
+    }
+    
+    func testThatItRecordsPublicLogsWhenLevelIsEnabled() {
+        struct Item: SafeForLoggingStringConvertible {
+            var name: String
+            var safeForLoggingDescription: String {
+                return "hidden"
+            }
+        }
+        
+        // GIVEN
+        let sut = ZMSLog(tag: "foo")
+        ZMSLog.set(level: .debug, tag: "foo")
+        let item = Item(name: "Secret")
+        ZMSLog.startRecording()
+        
+        // WHEN
+        sut.safePublic("Item: \(item)")
+        
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        // THEN
+        let lines = getLinesFromCurrentLog()
+        
         XCTAssertEqual(lines.count, 1)
-        XCTAssertTrue(lines.first!.hasSuffix("[0] [foo] Item: hidden"))
+        XCTAssertTrue(lines.first!.hasSuffix("[3] [foo] Item: hidden"))
     }
     
     func testThatItDiscardsLogsWhenStopped() {
@@ -540,7 +566,7 @@ extension ZMLogTests {
         //when
         ZMSLog.startRecording(isInternal: false)
         
-        sut.safePublic("PUBLIC")
+        sut.safePublic("PUBLIC", level: .public)
         
         ZMSLog.set(level: .error, tag: tag)
         sut.error("ERROR")
@@ -571,6 +597,7 @@ extension ZMLogTests {
         
         //when
         ZMSLog.startRecording(isInternal: true)
+        ZMSLog.set(level: .debug, tag: "tag")
         
         sut.safePublic("PUBLIC")
         
@@ -592,7 +619,7 @@ extension ZMLogTests {
         
         //then
         XCTAssertEqual(lines.count, 5)
-        XCTAssertTrue(lines[0].hasSuffix("[0] [tag] PUBLIC"))
+        XCTAssertTrue(lines[0].hasSuffix("[3] [tag] PUBLIC"))
         XCTAssertTrue(lines[1].hasSuffix("[1] [tag] ERROR"))
         XCTAssertTrue(lines[2].hasSuffix("[2] [tag] WARN"))
         XCTAssertTrue(lines[3].hasSuffix("[3] [tag] INFO"))


### PR DESCRIPTION
## What's new in this PR?

### Issue
Log level and log "Safety" for public builds are combined in the same variable. Therefore it is not possible to express the information that a log is safe, but should not be visible because the threshold is too low.

### Changes

The information of whether a log is safe has been moved to a separate parameter for the log. It is set to true only for `safePublic()` calls.