### PR TITLE
include file and line in fatalError

### DIFF
--- a/Source/ZMSAsserts.swift
+++ b/Source/ZMSAsserts.swift
@@ -20,13 +20,15 @@
 import Foundation
 
 /// Reports an error and terminates the application
-public func fatal(_ message: String, file: String = #file, line: Int = #line) -> Never  {
-    ZMAssertionDump_NSString("Swift assertion", file, Int32(line), message)
-    fatalError(message)
+public func fatal(_ message: String,
+                  file: StaticString = #file,
+                  line: UInt = #line) -> Never  {
+    ZMAssertionDump_NSString("Swift assertion", "\(file)", Int32(line), message)
+    fatalError(message, file: file, line: line)
 }
 
 /// If the condition is not true, reports an error and terminates the application
-public func require(_ condition: Bool, _ message: String = "", file: String = #file, line: Int = #line) {
+public func require(_ condition: Bool, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
     if(!condition) {
         fatal(message, file: file, line: line)
     }
@@ -52,13 +54,13 @@ public func require(_ condition: Bool, _ message: String = "", file: String = #f
 }
 
 /// Termiantes the application if the condition is `false` and the current build is not an AppsStore build
-public func requireInternal(_ condition: Bool, _ message: @autoclosure () -> String, file: String = #file, line: Int = #line) {
+public func requireInternal(_ condition: Bool, _ message: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) {
     guard !Environment.current.isAppStore, !condition else { return }
     fatal(message(), file: file, line: line)
 }
 
 /// Termiantes the application if the current build is not an AppsStore build
-public func requireInternalFailure(_ message: @autoclosure () -> String, file: String = #file, line: Int = #line) {
+public func requireInternalFailure(_ message: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) {
     guard !Environment.current.isAppStore else { return }
     fatal(message(), file: file, line: line)
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the crash logs, different kinds of crashes are grouped as the same kind.

### Causes

`fatalError` has no `file` and `line` parameters

### Solutions

Fill in the parameters.
Correct `file` 's type to `StaticString`