### PR TITLE
[Fix] Conform SanitizedString to SafeForLoggingStringConvertible

### DIFF
--- a/Source/SanitizedString.swift
+++ b/Source/SanitizedString.swift
@@ -34,6 +34,12 @@ extension SanitizedString: ExpressibleByStringInterpolation {
     }
 }
 
+extension SanitizedString: SafeForLoggingStringConvertible {
+    public var safeForLoggingDescription: String {
+        return self.value
+    }
+}
+
 extension SanitizedString: StringInterpolationProtocol {
     
     public init(literalCapacity: Int, interpolationCount: Int) {


### PR DESCRIPTION
## What's new in this PR?

Conform `SanitizedString` to `SafeForLoggingStringConvertible`