### PR TITLE
[Fix] race condition between writing logs and performing the sync() operation

### DIFF
--- a/Source/ZMSLog.swift
+++ b/Source/ZMSLog.swift
@@ -309,31 +309,27 @@ extension ZMSLog {
         updatingHandle = nil
     }
 
-    static public func appendToCurrentLog(_ string: String) {
+    static func appendToCurrentLog(_ string: String) {
         
         guard let currentLogURL = self.currentLogPath else { return }
         let currentLogPath = currentLogURL.path
-
-        logQueue.async {
-
-            let manager = FileManager.default
-
-            if !manager.fileExists(atPath: currentLogPath) {
-                manager.createFile(atPath: currentLogPath, contents: nil, attributes: nil)
-            }
-
-            if updatingHandle == nil {
-                updatingHandle = FileHandle(forUpdatingAtPath: currentLogPath)
-                updatingHandle?.seekToEndOfFile()
-            }
-
-            let data = Data(string.utf8)
-
-            do {
-                try updatingHandle?.wr_write(data)
-            } catch {
-                updatingHandle = nil
-            }
+        let manager = FileManager.default
+        
+        if !manager.fileExists(atPath: currentLogPath) {
+            manager.createFile(atPath: currentLogPath, contents: nil, attributes: nil)
+        }
+        
+        if updatingHandle == nil {
+            updatingHandle = FileHandle(forUpdatingAtPath: currentLogPath)
+            updatingHandle?.seekToEndOfFile()
+        }
+        
+        let data = Data(string.utf8)
+        
+        do {
+            try updatingHandle?.wr_write(data)
+        } catch {
+            updatingHandle = nil
         }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When writing a test, I was making the assumption that when I perform the following sequence of actions:

```
ZMSLog.debug("log statement 1")
ZMSLog.debug("log statement 2")
ZMSLog.sync()
```

I can rely on the fact that both log statements have been saved after `sync()` has been performed. This was not true.

### Causes

When writing a log statement two nested `async` operations are performed, first in `logEntry()` and then again in `appendToCurrentLog()`. This makes the `sync()` method useless since it will always only wait for the first async operation.

### Solutions

Remove the `async` invocation in `appendToCurrentLog()` it's already executing on the `logQueue`. `appendToCurrentLog()` is only called from the `logEntry()` code path. 

To make sure that's also the case in the future I'm also changing `appendToCurrentLog()` from `public` to `internal`.