### PR TITLE
[Feature] Signal if values where purged upon inserting a new value

### DIFF
--- a/Source/Cache.swift
+++ b/Source/Cache.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-/// In memory cache with support for  generics.
+/// In memory cache with support for generics.
 
 public class Cache<Key: Hashable, Value> {
     private var cache: [Key: EntryMetadata<Value>] = [:]
@@ -75,7 +75,7 @@ public class Cache<Key: Hashable, Value> {
         return didPurgeItems
     }
     
-    /// Retrieve a value from the Cache
+    /// Retrieve a value from the cache
     ///
     /// - Parameters:
     ///     - key: Key used to retrieve a previously stored value.

--- a/Source/Cache.swift
+++ b/Source/Cache.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 
+/// In memory cache with support for  generics.
+
 public class Cache<Key: Hashable, Value> {
     private var cache: [Key: EntryMetadata<Value>] = [:]
     private var cacheBuffer: CircularArray<Key>
@@ -35,6 +37,14 @@ public class Cache<Key: Hashable, Value> {
         }
     }
     
+    /// Create a new cache
+    ///
+    /// When any of the limits are reached the oldest value in the Cache will be removed first.
+    ///
+    /// - Parameters:
+    ///     - maxCost: Maximum cost which can be stored in cached before entries are purged.
+    ///     - maxElementsCount: Maximum number of elements which can be stored in the cached before entries are
+    ///       purged.
     public init(maxCost: Int, maxElementsCount: Int) {
         assert(maxCost > 0, "maxCost must be greather than 0")
         assert(maxElementsCount > 0, "maxElementsCount must be greather than 0")
@@ -43,37 +53,59 @@ public class Cache<Key: Hashable, Value> {
         cacheBuffer = CircularArray<Key>(size: maxElementsCount)
     }
     
-    public func set(value: Value, for key: Key, cost: Int) {
+    /// Add a value to the cache
+    ///
+    /// - Parameters:
+    ///     - value: Value which should be stored in the cache.
+    ///     - key: Key by which the value later can be retrieved.
+    ///     - cost: How much it costs to store value. This will be used to determine if values need purged
+    ///             from the cache when the cost limit has been reached.
+    /// - Returns: Boolean set to true if values had to be purged in order to make room for the new value,
+    ///            otherwise false.
+    @discardableResult
+    public func set(value: Value, for key: Key, cost: Int) -> Bool {
         assert(cost > 0, "Cost must be greather than 0")
         cache[key] = EntryMetadata(value: value, cost: cost)
         currentCost = currentCost + cost
-        purgeBasedOnElementsCount(adding: key)
-        purgeBasedOnCost()
+        
+        var didPurgeItems = false
+        didPurgeItems = didPurgeItems || purgeBasedOnElementsCount(adding: key)
+        didPurgeItems = didPurgeItems || purgeBasedOnCost()
+        
+        return didPurgeItems
     }
     
+    /// Retrieve a value from the Cache
+    ///
+    /// - Parameters:
+    ///     - key: Key used to retrieve a previously stored value.
+    /// - Returns: Value if it exists the cache.
     public func value(for key: Key) -> Value? {
         return cache[key]?.value
     }
     
+    /// Remove all values from the cache.
     public func purge() {
         cache.removeAll()
         cacheBuffer.clear()
         currentCost = 0
     }
 
-    private func purgeBasedOnElementsCount(adding key: Key) {
+    private func purgeBasedOnElementsCount(adding key: Key) -> Bool {
         guard let discardedElement = cacheBuffer.add(key) else {
-            return
+            return false
         }
         let metadata = cache[discardedElement]!
         currentCost = currentCost - metadata.cost
 
         cache[discardedElement] = nil
+        
+        return true
     }
     
-    private func purgeBasedOnCost() {
+    private func purgeBasedOnCost() -> Bool {
         guard currentCost > maxCost else {
-            return
+            return false
         }
         
         var elementsToDiscard: Int = 0
@@ -101,6 +133,8 @@ public class Cache<Key: Hashable, Value> {
         // rebuild cacheBuffer, since as many as `elementsToDiscard` number of elements must be discarded
         cacheBuffer = CircularArray(size: maxElementsCount,
                                     initialValue: Array(currentCacheBuffer.prefix(upTo: currentCacheBuffer.count - elementsToDiscard)))
+        
+        return true
     }
     
 }

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -24,21 +24,27 @@ class CacheTests: XCTestCase {
     func testThatItStoresAndReadsValue() {
         // GIVEN
         let cache = Cache<String, String>(maxCost: 1000, maxElementsCount: 10)
+        
         // WHEN
-        cache.set(value: "Hello", for: "word", cost: 1)
+        let didPurgeElements = cache.set(value: "Hello", for: "word", cost: 1)
+        
         // THEN
+        XCTAssertFalse(didPurgeElements)
         XCTAssertEqual(cache.value(for: "word"), "Hello")
     }
     
     func testThatItPurgesWhenTooManyElements() {
         // GIVEN
         let cache = Cache<String, String>(maxCost: 1000, maxElementsCount: 10)
-        // WHEN
-        (0..<11).forEach {
+
+        (0..<10).forEach {
             cache.set(value: "Hello \($0)", for: "word \($0)", cost: 1)
         }
+        // WHEN
+        let didPurgeElements = cache.set(value: "Hello \(10)", for: "word \(10)", cost: 1)
         
         // THEN
+        XCTAssertTrue(didPurgeElements)
         XCTAssertEqual(cache.value(for: "word 10"), "Hello 10")
         XCTAssertEqual(cache.value(for: "word 1"), "Hello 1")
         XCTAssertEqual(cache.value(for: "word 0"), nil)
@@ -47,13 +53,15 @@ class CacheTests: XCTestCase {
     func testThatItPurgesWhenCostIsTooHigh() {
         // GIVEN
         let cache = Cache<String, String>(maxCost: 10, maxElementsCount: 10)
-        // WHEN
         cache.set(value: "Hello 0", for: "word 0", cost: 2)
         cache.set(value: "Hello 1", for: "word 1", cost: 2)
         cache.set(value: "Hello 2", for: "word 2", cost: 2)
-        cache.set(value: "Hello 3", for: "word 3", cost: 5)
+        
+        // WHEN
+        let didPurgeElements = cache.set(value: "Hello 3", for: "word 3", cost: 5)
         
         // THEN
+        XCTAssertTrue(didPurgeElements)
         XCTAssertEqual(cache.value(for: "word 3"), "Hello 3")
         XCTAssertEqual(cache.value(for: "word 2"), "Hello 2")
         XCTAssertEqual(cache.value(for: "word 1"), "Hello 1")
@@ -63,14 +71,16 @@ class CacheTests: XCTestCase {
     func testThatItPurgesWhenCostIsTooHigh_MultipleDeletes() {
         // GIVEN
         let cache = Cache<String, String>(maxCost: 10, maxElementsCount: 10)
-        // WHEN
         cache.set(value: "Hello 0", for: "word 0", cost: 1)
         cache.set(value: "Hello 1", for: "word 1", cost: 1)
         cache.set(value: "Hello 2", for: "word 2", cost: 3)
         cache.set(value: "Hello 3", for: "word 3", cost: 5)
-        cache.set(value: "Hello 4", for: "word 4", cost: 5)
+        
+        // WHEN
+        let didPurgeElements = cache.set(value: "Hello 4", for: "word 4", cost: 5)
         
         // THEN
+        XCTAssertTrue(didPurgeElements)
         XCTAssertEqual(cache.value(for: "word 4"), "Hello 4")
         XCTAssertEqual(cache.value(for: "word 3"), "Hello 3")
         XCTAssertEqual(cache.value(for: "word 2"), nil)


### PR DESCRIPTION
## What's new in this PR?

- Signal if values where purged upon inserting a new value, by returning a boolean in the `set(value:for:cost:)` method.
- Document public methods