### PR TITLE
[Fix] Don't crash when purging cache multiple times

### DIFF
--- a/Source/Cache.swift
+++ b/Source/Cache.swift
@@ -131,8 +131,10 @@ public class Cache<Key: Hashable, Value> {
         }
 
         // rebuild cacheBuffer, since as many as `elementsToDiscard` number of elements must be discarded
-        cacheBuffer = CircularArray(size: maxElementsCount,
-                                    initialValue: Array(currentCacheBuffer.prefix(upTo: currentCacheBuffer.count - elementsToDiscard)))
+        let numberOfElementsToKeep = currentCacheBuffer.count - elementsToDiscard
+        let elementsToKeep = currentCacheBuffer.suffix(numberOfElementsToKeep)
+
+        cacheBuffer = CircularArray(size: maxElementsCount, initialValue: Array(elementsToKeep))
         
         return true
     }

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -88,6 +88,38 @@ class CacheTests: XCTestCase {
         XCTAssertEqual(cache.value(for: "word 0"), nil)
     }
 
+    func testThatItPurgesWhenCostIsTooHigh_MultiplePurges() {
+        // GIVEN
+        let cache = Cache<String, String>(maxCost: 10, maxElementsCount: 10)
+        cache.set(value: "Hello 0", for: "word 0", cost: 1)
+        cache.set(value: "Hello 1", for: "word 1", cost: 1)
+        cache.set(value: "Hello 2", for: "word 2", cost: 3)
+        cache.set(value: "Hello 3", for: "word 3", cost: 5)
+
+        // WHEN
+        var didPurgeElements = cache.set(value: "Hello 4", for: "word 4", cost: 2)
+
+        // THEN
+        XCTAssertTrue(didPurgeElements)
+        XCTAssertEqual(cache.value(for: "word 4"), "Hello 4")
+        XCTAssertEqual(cache.value(for: "word 3"), "Hello 3")
+        XCTAssertEqual(cache.value(for: "word 2"), "Hello 2")
+        XCTAssertEqual(cache.value(for: "word 1"), nil)
+        XCTAssertEqual(cache.value(for: "word 0"), nil)
+
+        // WHEN
+        didPurgeElements = cache.set(value: "Hello 5", for: "word 5", cost: 2)
+
+        // THEN
+        XCTAssertTrue(didPurgeElements)
+        XCTAssertEqual(cache.value(for: "word 5"), "Hello 5")
+        XCTAssertEqual(cache.value(for: "word 4"), "Hello 4")
+        XCTAssertEqual(cache.value(for: "word 3"), "Hello 3")
+        XCTAssertEqual(cache.value(for: "word 2"), nil)
+        XCTAssertEqual(cache.value(for: "word 1"), nil)
+        XCTAssertEqual(cache.value(for: "word 0"), nil)
+    }
+
     func testThatPurgeResetsContent() {
         // GIVEN
         let cache = Cache<String, String>(maxCost: 5, maxElementsCount: 5)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Purging the cache for the second time could cause a force unwrap to crash the app.

### Causes

The cache contains two collections, firstly `cache` which is a dictionary for fast lookup of values, and secondly a `cacheBuffer` which contains the keys for iteration and is used to enforce size limits of the cache.

When an element is added to the cache that causes the maximum cost to be exceeded, the cache will purge enough elements to reduce the cost to below the maximum threshold. It does this by iterating through the keys in the `cacheBuffer`, removing the key from the `cache` dictionary and then subsequently recalculating the `cacheBuffer` to remove the discarded keys.

The crash is caused when purging the cache for the second time, we encounter a key in the `cacheBuffer` that has already been deleted from the `cache` dictionary. The key is expected to in the dictionary, so it is forced unwrapped.

The issue is not so much about the force unwrap since it's a valid expectation that the `cache` and the `cacheBuffer` are in sync. The issue lies in the fact that we discard the wrong keys from the `cacheBuffer` after purging. Specifically, we remove the first `n` keys from the `cache`, but then we drop the last `n` keys from the `cacheBuffer`. The next time the cache needs to be purged, we will encounter an old key that was not properly discarded after the first purge.

### Solutions

Don't take the `prefix` of the `cacheBuffer`, but rather the `suffix`, since we are discarding the first `n` keys.

### Notes:

**JIRA:** https://wearezeta.atlassian.net/browse/ZIOS-13143