### PR TITLE
Add interpolation and concatenation of SanitizedString

### DIFF
--- a/Source/SanitizedString.swift
+++ b/Source/SanitizedString.swift
@@ -47,10 +47,31 @@ extension SanitizedString: StringInterpolationProtocol {
     public mutating func appendInterpolation<T: SafeForLoggingStringConvertible>(_ x: T?) {
         value += x?.safeForLoggingDescription ?? "nil"
     }
+    
+    public static func +<T: SafeForLoggingStringConvertible>(lhs: SanitizedString, rhs: T) -> SanitizedString {
+        return SanitizedString(value: lhs.value + rhs.safeForLoggingDescription)
+    }
 }
 
 extension SanitizedString: CustomStringConvertible {
+    
     public var description: String {
         return value
     }
+}
+
+extension SanitizedString: SafeForLoggingStringConvertible {
+    public var safeForLoggingDescription: String {
+        return self.value
+    }
+}
+
+extension Optional: SafeForLoggingStringConvertible
+    where Wrapped: SafeForLoggingStringConvertible {
+    
+    public var safeForLoggingDescription: String {
+        return self.map { $0.safeForLoggingDescription } ?? "nil"
+    }
+    
+    
 }

--- a/Tests/SanitizedStringTests.swift
+++ b/Tests/SanitizedStringTests.swift
@@ -61,6 +61,21 @@ class SanitizedStringTests: XCTestCase {
         let result = SanitizedString(stringLiteral: "some \(Item.redacted) item")
         XCTAssertEqual(result, interpolated)
     }
+    
+    func testAddition() {
+        XCTAssertEqual(
+            SanitizedString(value: "<redacted>foo"),
+            SanitizedString("\(item)") + SanitizedString(value: "foo")
+        )
+        XCTAssertEqual(
+            SanitizedString(value: "<redacted><redacted>"),
+            SanitizedString("\(item)") + item
+        )
+        XCTAssertEqual(
+            SanitizedString(value: "<redacted>nil"),
+            SanitizedString("\(item)") + Optional<Item>(nil)
+        )
+    }
 }
 
 extension SanitizedStringTests {
@@ -69,6 +84,13 @@ extension SanitizedStringTests {
         let value = SafeValueForLogging(sut)
         let result: SanitizedString = "\(value)"
         XCTAssertEqual(sut, result.value)
+    }
+    
+    func testSanitizedString() {
+        let sut = SanitizedString("some")
+        let value = SafeValueForLogging(sut)
+        let result: SanitizedString = "\(value)"
+        XCTAssertEqual(sut, result)
     }
     
     func testInt() {


### PR DESCRIPTION
## What's new in this PR?

Add interpolation and concatenation of `SanitizedString`. Before this PR, a `SanitizedString` itself could not be used in string interpolation to create a `SanitizedString`.