### PR TITLE
fix run time error when test with m1 mac

### DIFF
--- a/Resources/Configurations/zmc-config/project-common.xcconfig
+++ b/Resources/Configurations/zmc-config/project-common.xcconfig
@@ -23,7 +23,7 @@
 //
 SDKROOT = iphoneos
 ARCHS[sdk=iphoneos*] = arm64 armv7
-ARCHS[sdk=iphonesimulator*] = x86_64
+ARCHS[sdk=iphonesimulator*] = x86_64 arm64
 VALID_ARCHS[sdk=iphoneos*] = arm64 armv7
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator
 

--- a/WireSystem.xcodeproj/project.pbxproj
+++ b/WireSystem.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 092758691B70E68F00AD5A78 /* WireSystem.xcconfig */;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/WireSystem-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireSystem;
 			};
@@ -462,6 +463,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 092758691B70E68F00AD5A78 /* WireSystem.xcconfig */;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/WireSystem-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireSystem;
 			};
@@ -471,6 +473,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 546BC7D51EFD49B400DDB12A /* test-target.xcconfig */;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
 				INFOPLIST_FILE = Tests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wire.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -482,6 +485,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 546BC7D51EFD49B400DDB12A /* test-target.xcconfig */;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
 				INFOPLIST_FILE = Tests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wire.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/WireSystem.xcodeproj/project.pbxproj
+++ b/WireSystem.xcodeproj/project.pbxproj
@@ -453,7 +453,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 092758691B70E68F00AD5A78 /* WireSystem.xcconfig */;
 			buildSettings = {
-				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/WireSystem-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireSystem;
 			};
@@ -463,7 +462,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 092758691B70E68F00AD5A78 /* WireSystem.xcconfig */;
 			buildSettings = {
-				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/WireSystem-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireSystem;
 			};
@@ -473,7 +471,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 546BC7D51EFD49B400DDB12A /* test-target.xcconfig */;
 			buildSettings = {
-				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
 				INFOPLIST_FILE = Tests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wire.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -485,7 +482,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 546BC7D51EFD49B400DDB12A /* test-target.xcconfig */;
 			buildSettings = {
-				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
 				INFOPLIST_FILE = Tests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wire.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## What's new in this PR?

### Issues

When running test on M1 Mac, test can not started.

### Causes

`The bundle “WireSystem Tests” couldn’t be loaded because it doesn’t contain a version for the current architecture. Try installing a universal version of the bundle.`

### Solutions

Add support for arm64 arch for simulator.

### TODO
- [x] move the change to .xcconfig
- [ ] move `project-common.xcconfig` to `wire-ios-build-configuration` repo