### PR TITLE
Add bump version GitHub action

### DIFF
--- a/.github/workflows/bumpVersion.yml
+++ b/.github/workflows/bumpVersion.yml
@@ -13,7 +13,7 @@ jobs:
         fetch-depth: '0'
 
     - name: guard for wire bot commit
-      if: ${{ github.event.head_commit.author.email == 'iosx+bot@wire.com' || github.event.head_commit.message == '[skip release]'}}
+      if: ${{ github.event.head_commit.author.email == 'iosx+bot@wire.com' || contains(github.event.head_commit.message, '[skip release]')}}
       run: |
           echo "exit for wire bot commit or skip release"
           exit 1

--- a/.github/workflows/bumpVersion.yml
+++ b/.github/workflows/bumpVersion.yml
@@ -19,7 +19,7 @@ jobs:
           exit 1
 
     - name: Bump version and push tag, dry run to get the next tag
-      uses: anothrNick/github-tag-action@1.26.0
+      uses: wireapp/github-tag-action@1.26.0
       id: dry_run
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
         git push || true
 
     - name: Bump version and push tag, after version.xcconfig is updated
-      uses: anothrNick/github-tag-action@1.26.0
+      uses: wireapp/github-tag-action@1.26.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_BRANCHES: develop

--- a/.github/workflows/bumpVersion.yml
+++ b/.github/workflows/bumpVersion.yml
@@ -1,0 +1,47 @@
+name: Bump version
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+      run: |
+        echo ${{ github.event.head_commit.message }}
+        echo ${{ github.event.author.email }}
+    - name: Bump version and push tag, dry run to get the next tag
+      uses: anothrNick/github-tag-action@1.26.0
+      id: dry_run
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_BRANCHES: develop
+        DEFAULT_BUMP: patch
+        DRY_RUN: true
+        
+    - name: update version.xcconfig
+      run: |
+        echo "new tag: '${{steps.dry_run.outputs.new_tag}}'"
+        echo "tag: '${{steps.dry_run.outputs.tag}}'"
+        # process version.xcconfig
+        curl --silent https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master/Scripts/updateVersionXcconfig.swift --output updateVersionXcconfig.swift
+        chmod +x updateVersionXcconfig.swift
+        swift updateVersionXcconfig.swift ./Resources/Configurations/version.xcconfig ${{steps.dry_run.outputs.new_tag}}
+        rm updateVersionXcconfig.swift
+        
+        git config --global user.email "iosx@wire.com"
+        git config --global user.name "Github action - Bump version"
+        git add .
+        git commit -m"[skip ci] update version.xcconfig for '${{steps.dry_run.outputs.new_tag}}'" || true
+        git push || true
+
+    - name: Bump version and push tag, after version.xcconfig is updated
+      uses: anothrNick/github-tag-action@1.26.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_BRANCHES: develop
+        DEFAULT_BUMP: patch

--- a/.github/workflows/bumpVersion.yml
+++ b/.github/workflows/bumpVersion.yml
@@ -11,9 +11,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
+
+    - name: guard for wire bot commit
+      if: ${{ github.event.head_commit.author.email == 'iosx+bot@wire.com' || github.event.head_commit.message == '[skip release]'}}
       run: |
-        echo ${{ github.event.head_commit.message }}
-        echo ${{ github.event.author.email }}
+          echo "exit for wire bot commit or skip release"
+          exit 1
+
     - name: Bump version and push tag, dry run to get the next tag
       uses: anothrNick/github-tag-action@1.26.0
       id: dry_run
@@ -22,6 +26,7 @@ jobs:
         RELEASE_BRANCHES: develop
         DEFAULT_BUMP: patch
         DRY_RUN: true
+        VERBOSE: true
         
     - name: update version.xcconfig
       run: |


### PR DESCRIPTION
## What's new in this PR?

### Issues

The Jenkins GitHub comment monitoring is unstable and some times does not trigger release 

### Causes

Possible reasons: unstable connection between Jenkins and Github/Jenkins plugin is outdated/some API limitation changes of Github...

### Solutions

We can archive same function with Github actions `anothrNick/github-tag-action`. 
The action performs following steps:
When `develop` branch has pushed new commit
1. clone the repo shallowly
2. check the commit info, if the author is `iosx+bot@wire.com`(Jenkins pipeline commit) or the commit message is  contains `[skip release]` String, exit
3. dry run `github-tag-action` to get the next version 
4. update the `version.xcconfig` file with the next version, commit and push the change (use `[skip ci]` to prevent CI run repeatedly in next step )
5.run `github-tag-action` now to create a version tag on the commit in step 4

For detail usage please ref to https://github.com/anothrNick/github-tag-action

The testing repo of this action is here: 
https://github.com/billypchan/wire-ios-sync-engine/runs/2873604898?check_suite_focus=true

Github action String functions reference:
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions

Needs releases with:

- [x] Fork `anothrNick/github-tag-action`

