### PR TITLE
clean up VALID_ARCHS

### DIFF
--- a/Resources/Configurations/zmc-config/ios.xcconfig
+++ b/Resources/Configurations/zmc-config/ios.xcconfig
@@ -27,8 +27,6 @@
 SDKROOT = iphoneos
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator
 
-VALID_ARCHS[sdk=iphoneos*] = arm64 armv7
-
 ARCHS[sdk=iphoneos*] = arm64 armv7
 ARCHS[sdk=iphonesimulator*] = x86_64
 


### PR DESCRIPTION
## What's new in this PR?

clean up VALID_ARCHS which is no long used in Xcode 12