### PR TITLE
fix: build with Xcode 12.4 SQPIT-781

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,3 +14,5 @@ trigger:
 
 jobs:
   - template: Azure/framework-pipelines.yml@wire-ios-shared-resources
+      parameters:
+       xcodeAppName: Xcode_12.4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQPIT-781" title="SQPIT-781" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQPIT-781</a>  Build frameworks compiles on both Xcode 12 and 13
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
release framework with Xcode 12.4 